### PR TITLE
Themes for the main ChatGPT page.

### DIFF
--- a/manifests/mv2-manifest/manifest.json
+++ b/manifests/mv2-manifest/manifest.json
@@ -24,7 +24,7 @@
     }
   ],
   "web_accessible_resources" : ["content-scripts/prompts.js"
-    ,"themes/none.css","themes/cozy-fireplace.css"],
+    ,"themes/none.css","themes/cozy-fireplace.css","themes/hacker.css"],
   "browser_action": {
     "default_title": "ChatGPT History"
   },

--- a/manifests/mv2-manifest/manifest.json
+++ b/manifests/mv2-manifest/manifest.json
@@ -13,8 +13,8 @@
   "content_scripts": [
     {
       "matches": ["https://chat.openai.com/chat*"],
-      "js": ["content-scripts/scraper.js", "content-scripts/prompt-inject.js", "content-scripts/export.js", "external-js/html2canvas.js",
-        "external-js/jspdf.umd.js"],
+      "js": ["content-scripts/scraper.js", "content-scripts/prompt-inject.js", "content-scripts/export.js", "content-scripts/themes.js"
+	    ,"external-js/html2canvas.js", "external-js/jspdf.umd.js"],
       "run_at": "document_idle"
     },
     {

--- a/manifests/mv2-manifest/manifest.json
+++ b/manifests/mv2-manifest/manifest.json
@@ -24,7 +24,7 @@
     }
   ],
   "web_accessible_resources" : ["content-scripts/prompts.js"
-    ,"themes/none.css","themes/cozy-fireplace.css","themes/hacker.css"],
+    ,"themes/none.css","themes/cozy-fireplace.css","themes/hacker.css","themes/sms.css"],
   "browser_action": {
     "default_title": "ChatGPT History"
   },

--- a/manifests/mv2-manifest/manifest.json
+++ b/manifests/mv2-manifest/manifest.json
@@ -23,7 +23,7 @@
       "run_at": "document_idle"
     }
   ],
-  "web_accessible_resources" : ["content-scripts/prompts.js"],
+  "web_accessible_resources" : ["content-scripts/prompts.js", "themes/novel.css"],
   "browser_action": {
     "default_title": "ChatGPT History"
   },

--- a/manifests/mv2-manifest/manifest.json
+++ b/manifests/mv2-manifest/manifest.json
@@ -24,7 +24,7 @@
     }
   ],
   "web_accessible_resources" : ["content-scripts/prompts.js"
-    ,"themes/novel.css","themes/cozy-fireplace.css"],
+    ,"themes/none.css","themes/cozy-fireplace.css"],
   "browser_action": {
     "default_title": "ChatGPT History"
   },

--- a/manifests/mv2-manifest/manifest.json
+++ b/manifests/mv2-manifest/manifest.json
@@ -23,7 +23,8 @@
       "run_at": "document_idle"
     }
   ],
-  "web_accessible_resources" : ["content-scripts/prompts.js", "themes/novel.css"],
+  "web_accessible_resources" : ["content-scripts/prompts.js"
+    ,"themes/novel.css","themes/cozy-fireplace.css"],
   "browser_action": {
     "default_title": "ChatGPT History"
   },

--- a/manifests/mv3-manifest/manifest.json
+++ b/manifests/mv3-manifest/manifest.json
@@ -22,7 +22,7 @@
   ],
   "web_accessible_resources" : [{
     "resources": ["content-scripts/prompts.js"
-      ,"themes/novel.css","themes/cozy-fireplace.css"],
+      ,"themes/none.css","themes/cozy-fireplace.css"],
     "matches": ["https://chat.openai.com/*"],
     "use_dynamic_url": true
   }],

--- a/manifests/mv3-manifest/manifest.json
+++ b/manifests/mv3-manifest/manifest.json
@@ -21,7 +21,7 @@
     }
   ],
   "web_accessible_resources" : [{
-    "resources": ["content-scripts/prompts.js"],
+    "resources": ["content-scripts/prompts.js", "themes/novel.css"],
     "matches": ["https://chat.openai.com/*"],
     "use_dynamic_url": true
   }],

--- a/manifests/mv3-manifest/manifest.json
+++ b/manifests/mv3-manifest/manifest.json
@@ -21,7 +21,8 @@
     }
   ],
   "web_accessible_resources" : [{
-    "resources": ["content-scripts/prompts.js", "themes/novel.css"],
+    "resources": ["content-scripts/prompts.js"
+      ,"themes/novel.css","themes/cozy-fireplace.css"],
     "matches": ["https://chat.openai.com/*"],
     "use_dynamic_url": true
   }],

--- a/manifests/mv3-manifest/manifest.json
+++ b/manifests/mv3-manifest/manifest.json
@@ -22,7 +22,7 @@
   ],
   "web_accessible_resources" : [{
     "resources": ["content-scripts/prompts.js"
-      ,"themes/none.css","themes/cozy-fireplace.css"],
+      ,"themes/none.css","themes/cozy-fireplace.css","themes/hacker.css"],
     "matches": ["https://chat.openai.com/*"],
     "use_dynamic_url": true
   }],

--- a/manifests/mv3-manifest/manifest.json
+++ b/manifests/mv3-manifest/manifest.json
@@ -22,7 +22,7 @@
   ],
   "web_accessible_resources" : [{
     "resources": ["content-scripts/prompts.js"
-      ,"themes/none.css","themes/cozy-fireplace.css","themes/hacker.css"],
+      ,"themes/none.css","themes/cozy-fireplace.css","themes/hacker.css","themes/sms.css"],
     "matches": ["https://chat.openai.com/*"],
     "use_dynamic_url": true
   }],

--- a/manifests/mv3-manifest/manifest.json
+++ b/manifests/mv3-manifest/manifest.json
@@ -10,8 +10,8 @@
   "content_scripts": [
     {
       "matches": ["https://chat.openai.com/chat*"],
-      "js": ["content-scripts/scraper.js", "content-scripts/prompt-inject.js", "content-scripts/export.js","external-js/html2canvas.js",
-        "external-js/jspdf.umd.js"],
+      "js": ["content-scripts/scraper.js", "content-scripts/prompt-inject.js", "content-scripts/export.js", "content-scripts/themes.js"
+	    ,"external-js/html2canvas.js", "external-js/jspdf.umd.js"],
       "run_at": "document_idle"
     },
     {

--- a/src/content-scripts/export.js
+++ b/src/content-scripts/export.js
@@ -63,7 +63,8 @@ function main() {
         buttons = settings.buttons
         if (buttons === true) {
             if (!document.getElementById('download-markdown-button')) {
-                add_buttons()
+                add_buttons();
+				readdThemeSelect(); // just going to yoink this in here, from themes.js, as this is more convenient.
             }
         }
     })

--- a/src/content-scripts/prompts.js
+++ b/src/content-scripts/prompts.js
@@ -221,7 +221,6 @@ function insertPromptTemplatesSection () {
     let wrapper = document.createElement('div')
     wrapper.id = 'templates-wrapper'
     wrapper.className = 'mt-6 flex items-start text-center gap-3.5'
-	wrapper.style.marginBottom = "4rem";
 
     if (parent.querySelector('#templates-wrapper')) {
         wrapper = parent.querySelector('#templates-wrapper')

--- a/src/content-scripts/prompts.js
+++ b/src/content-scripts/prompts.js
@@ -221,6 +221,7 @@ function insertPromptTemplatesSection () {
     let wrapper = document.createElement('div')
     wrapper.id = 'templates-wrapper'
     wrapper.className = 'mt-6 flex items-start text-center gap-3.5'
+	wrapper.style.marginBottom = "4rem";
 
     if (parent.querySelector('#templates-wrapper')) {
         wrapper = parent.querySelector('#templates-wrapper')

--- a/src/content-scripts/themes.js
+++ b/src/content-scripts/themes.js
@@ -66,7 +66,7 @@ function addThemeSelectButton()
 	noThemeOption.innerHTML = "No Theme";
 	themeSelect.appendChild(noThemeOption);
 	
-	let themesList = ["cozy-fireplace.css"];
+	let themesList = ["cozy-fireplace.css","hacker.css"];
 	for(index = 0; index < themesList.length; index++)
 	{
 		let themeOption = document.createElement("option");

--- a/src/content-scripts/themes.js
+++ b/src/content-scripts/themes.js
@@ -24,7 +24,8 @@ function changeTheme(theme)
 	themeStylesheet.setAttribute('href', browser.runtime.getURL(theme));
 }
 
-// theme selector 
+// theme selector
+let themeSelectElement;
 function addThemeSelectButton()
 {
 	let icon = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" width="1em" height="1em" style="fill: white" stroke="currentColor" ><path d="M512 256c0 .9 0 1.8 0 2.7c-.4 36.5-33.6 61.3-70.1 61.3H344c-26.5 0-48 21.5-48 48c0 3.4 .4 6.7 1 9.9c2.1 10.2 6.5 20 10.8 29.9c6.1 13.8 12.1 27.5 12.1 42c0 31.8-21.6 60.7-53.4 62c-3.5 .1-7 .2-10.6 .2C114.6 512 0 397.4 0 256S114.6 0 256 0S512 114.6 512 256zM128 288c0-17.7-14.3-32-32-32s-32 14.3-32 32s14.3 32 32 32s32-14.3 32-32zm0-96c17.7 0 32-14.3 32-32s-14.3-32-32-32s-32 14.3-32 32s14.3 32 32 32zM288 96c0-17.7-14.3-32-32-32s-32 14.3-32 32s14.3 32 32 32s32-14.3 32-32zm96 96c17.7 0 32-14.3 32-32s-14.3-32-32-32s-32 14.3-32 32s14.3 32 32 32z"/></svg>`;
@@ -86,6 +87,17 @@ function addThemeSelectButton()
 	
 	var nav = document.querySelector("nav");
 	nav.appendChild(wrapper);
+	
+	themeSelectElement = wrapper;
 }
 
 addThemeSelectButton();
+
+/*
+	Re-add buttons hack.
+ */
+function readdThemeSelect()
+{
+	var nav = document.querySelector("nav");
+	nav.appendChild(themeSelectElement);
+}

--- a/src/content-scripts/themes.js
+++ b/src/content-scripts/themes.js
@@ -3,10 +3,13 @@ console.log(`Loading themes...`);
 // the way that themes work is to inject it after everything else.
 // remember to expose themes in web_accessible_resources
 // inject theme 
+var themeStylesheet;
+
 function injectStyle(file)
 {	
 	let head = document.querySelector('head');
     let stylesheet = document.createElement('link');
+	themeStylesheet = stylesheet;
     stylesheet.setAttribute('rel', 'stylesheet');
     stylesheet.setAttribute('type', 'text/css');
     stylesheet.setAttribute('href', file);
@@ -15,4 +18,46 @@ function injectStyle(file)
 
 injectStyle(browser.runtime.getURL('themes/cozy-fireplace.css'));
 
+// theme selector 
+function addThemeSelectButton()
+{
+	let icon = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" width="1em" height="1em" style="fill: white" stroke="currentColor" ><path d="M512 256c0 .9 0 1.8 0 2.7c-.4 36.5-33.6 61.3-70.1 61.3H344c-26.5 0-48 21.5-48 48c0 3.4 .4 6.7 1 9.9c2.1 10.2 6.5 20 10.8 29.9c6.1 13.8 12.1 27.5 12.1 42c0 31.8-21.6 60.7-53.4 62c-3.5 .1-7 .2-10.6 .2C114.6 512 0 397.4 0 256S114.6 0 256 0S512 114.6 512 256zM128 288c0-17.7-14.3-32-32-32s-32 14.3-32 32s14.3 32 32 32s32-14.3 32-32zm0-96c17.7 0 32-14.3 32-32s-14.3-32-32-32s-32 14.3-32 32s14.3 32 32 32zM288 96c0-17.7-14.3-32-32-32s-32 14.3-32 32s14.3 32 32 32s32-14.3 32-32zm96 96c17.7 0 32-14.3 32-32s-14.3-32-32-32s-32 14.3-32 32s14.3 32 32 32z"/></svg>`;
 	
+	let wrapper = document.createElement("a");
+	wrapper.id = "theme-select-button";
+	wrapper.setAttribute("class", 'flex py-3 px-3 items-center gap-3 rounded-md hover:bg-gray-500/10 transition-colors duration-200 text-white cursor-pointer text-sm');
+	wrapper.innerHTML = `${icon}`;
+	
+	let themeSelect = document.createElement("select");
+	themeSelect.style.background = "transparent";
+	themeSelect.style.height = "19px";
+	themeSelect.style.width = "100%";
+	themeSelect.style.padding = "0";
+	themeSelect.style.color = "inherit";
+	themeSelect.style.fontFamily = "inherit";
+	themeSelect.style.fontSize = "inherit";
+	themeSelect.style.overflow = "visible";
+	themeSelect.style.border = "0";
+	
+	
+	let noThemeOption = document.createElement("option");
+	noThemeOption.value = "";
+	noThemeOption.innerHTML = "No Theme";
+	themeSelect.appendChild(noThemeOption);
+	
+	let themesList = ["cozy-fireplace.css"];
+	for(index = 0; index < themesList.length; index++)
+	{
+		let themeOption = document.createElement("option");
+		themeOption.value = themesList[index];
+		themeOption.innerHTML = themesList[index];
+		themeSelect.appendChild(themeOption);
+	}
+	
+	wrapper.appendChild(themeSelect);
+	
+	var nav = document.querySelector("nav");
+	nav.appendChild(wrapper);
+}
+
+addThemeSelectButton();

--- a/src/content-scripts/themes.js
+++ b/src/content-scripts/themes.js
@@ -13,6 +13,6 @@ function injectStyle(file)
     head.appendChild(stylesheet);
 }
 
-injectStyle(browser.runtime.getURL('themes/novel.css'));
+injectStyle(browser.runtime.getURL('themes/cozy-fireplace.css'));
 
 	

--- a/src/content-scripts/themes.js
+++ b/src/content-scripts/themes.js
@@ -3,6 +3,7 @@ console.log(`Loading themes...`);
 // the way that themes work is to inject it after everything else.
 // remember to expose themes in web_accessible_resources
 // inject theme 
+const THEMES_LIST = ["cozy-fireplace.css","hacker.css"];
 var themeStylesheet;
 
 function injectStyle(file)
@@ -16,7 +17,7 @@ function injectStyle(file)
     head.appendChild(stylesheet);
 }
 
-injectStyle(browser.runtime.getURL('themes/cozy-fireplace.css'));
+injectStyle(browser.runtime.getURL('themes/none.css'));
 
 function changeTheme(theme)
 {
@@ -67,7 +68,7 @@ function addThemeSelectButton()
 	noThemeOption.innerHTML = "No Theme";
 	themeSelect.appendChild(noThemeOption);
 	
-	let themesList = ["cozy-fireplace.css","hacker.css"];
+	let themesList = THEMES_LIST;
 	for(index = 0; index < themesList.length; index++)
 	{
 		let themeOption = document.createElement("option");
@@ -75,12 +76,13 @@ function addThemeSelectButton()
 		themeOption.style.color = "black";
 		themeOption.innerHTML = themesList[index];
 		themeSelect.appendChild(themeOption);
-		
+		/*
 		if(themesList[index] === "cozy-fireplace.css") 
 		{
 			// default selected 
 			themeOption.setAttribute("selected","true");
 		}
+		*/
 	}
 	
 	wrapper.appendChild(themeSelect);

--- a/src/content-scripts/themes.js
+++ b/src/content-scripts/themes.js
@@ -1,0 +1,1 @@
+console.log(`Loading themes...`);

--- a/src/content-scripts/themes.js
+++ b/src/content-scripts/themes.js
@@ -18,6 +18,12 @@ function injectStyle(file)
 
 injectStyle(browser.runtime.getURL('themes/cozy-fireplace.css'));
 
+function changeTheme(theme)
+{
+	// because dynamic paths, otherwise it won't work
+	themeStylesheet.setAttribute('href', browser.runtime.getURL(theme));
+}
+
 // theme selector 
 function addThemeSelectButton()
 {
@@ -39,9 +45,24 @@ function addThemeSelectButton()
 	themeSelect.style.overflow = "visible";
 	themeSelect.style.border = "0";
 	
+	themeSelect.addEventListener("change", (event)=>
+	{
+		let themeFile = themeSelect.value;
+		console.log(`${themeFile} selected!`);
+		
+		if(themeFile === "")
+		{
+			changeTheme("themes/none.css");
+		}
+		else 
+		{
+			changeTheme("themes/" + themeFile);
+		}
+	});
 	
 	let noThemeOption = document.createElement("option");
 	noThemeOption.value = "";
+	noThemeOption.style.color = "black";
 	noThemeOption.innerHTML = "No Theme";
 	themeSelect.appendChild(noThemeOption);
 	
@@ -50,8 +71,15 @@ function addThemeSelectButton()
 	{
 		let themeOption = document.createElement("option");
 		themeOption.value = themesList[index];
+		themeOption.style.color = "black";
 		themeOption.innerHTML = themesList[index];
 		themeSelect.appendChild(themeOption);
+		
+		if(themesList[index] === "cozy-fireplace.css") 
+		{
+			// default selected 
+			themeOption.setAttribute("selected","true");
+		}
 	}
 	
 	wrapper.appendChild(themeSelect);

--- a/src/content-scripts/themes.js
+++ b/src/content-scripts/themes.js
@@ -3,7 +3,7 @@ console.log(`Loading themes...`);
 // the way that themes work is to inject it after everything else.
 // remember to expose themes in web_accessible_resources
 // inject theme 
-const THEMES_LIST = ["cozy-fireplace.css","hacker.css"];
+const THEMES_LIST = ["cozy-fireplace.css","hacker.css","sms.css"];
 var themeStylesheet;
 
 function injectStyle(file)

--- a/src/content-scripts/themes.js
+++ b/src/content-scripts/themes.js
@@ -1,1 +1,18 @@
 console.log(`Loading themes...`);
+
+// the way that themes work is to inject it after everything else.
+// remember to expose themes in web_accessible_resources
+// inject theme 
+function injectStyle(file)
+{	
+	let head = document.querySelector('head');
+    let stylesheet = document.createElement('link');
+    stylesheet.setAttribute('rel', 'stylesheet');
+    stylesheet.setAttribute('type', 'text/css');
+    stylesheet.setAttribute('href', file);
+    head.appendChild(stylesheet);
+}
+
+injectStyle(browser.runtime.getURL('themes/novel.css'));
+
+	

--- a/src/themes/cozy-fireplace.css
+++ b/src/themes/cozy-fireplace.css
@@ -24,6 +24,11 @@ main > div:last-child
 	
 }
 
+.dark main > div:first-child > div 
+{
+	background: transparent;
+}
+
 .dark main > div:last-child
 {
 	/* Disable that weird gradient */
@@ -46,11 +51,14 @@ main .h-full.flex-col > div
 	
 }
 
+main .h-full.flex-col > div > h1.text-center, /* Only select the ChatGPT main header */
 main .h-full.flex-col > div > div
 {	
 	background: white;
 	box-shadow: 0 0 10px rgba(0,0,0,1.0);
 	margin-top: 20px;
+	padding-top :20px;
+	padding-bottom :20px;
 	padding-left: 80px;
 	padding-right: 80px;
 	border-radius: 10px;
@@ -59,6 +67,7 @@ main .h-full.flex-col > div > div
 	max-width: 60rem;
 }
 
+.dark main .h-full.flex-col > div > h1.text-center, /* Only select the ChatGPT main header */
 .dark main .h-full.flex-col > div > div
 {	
 	background: rgb(52,53,65);

--- a/src/themes/cozy-fireplace.css
+++ b/src/themes/cozy-fireplace.css
@@ -5,7 +5,12 @@
 /* background */
 main 
 {
-	background-image: url("https://www.logsplittersdirect.com/images/stories/submitted/social_img_1798.jpg");
+	background: 
+		linear-gradient(
+          rgba(0, 0, 0, 0.7), 
+          rgba(0, 0, 0, 0.7)
+        ),
+		url("https://www.logsplittersdirect.com/images/stories/submitted/social_img_1798.jpg");
 	background-repeat: no-repeat;
 	background-size: cover;
 }

--- a/src/themes/cozy-fireplace.css
+++ b/src/themes/cozy-fireplace.css
@@ -1,0 +1,77 @@
+/*
+	A cozy fireplace.
+ */
+
+/* background */
+main 
+{
+	background-image: url("https://www.logsplittersdirect.com/images/stories/submitted/social_img_1798.jpg");
+	background-repeat: no-repeat;
+	background-size: cover;
+}
+
+main > div:last-child
+{
+	/* Disable that weird gradient */
+	background-color: rgba(255,255,255,100) !important;
+	box-shadow: 0 -10px 10px rgba(0,0,0,0.3);
+
+	
+}
+
+.dark main > div:last-child
+{
+	/* Disable that weird gradient */
+	background-color: rgba(52,53,65,100) !important;
+	box-shadow: 0 -10px 10px rgba(0,0,0,0.3);
+}
+
+main .h-full.flex-col
+{
+	background: none;
+}
+ 
+/* Foolproof (TM) Individual Chat Node Selector */
+main .h-full.flex-col > div
+{	
+	background: none; /* transparent it so we can see the background image */
+	/* Font */
+	font-family: "Courier", "Times New Roman", serif;
+	
+	
+}
+
+main .h-full.flex-col > div > div
+{	
+	background: white;
+	box-shadow: 0 0 10px rgba(0,0,0,1.0);
+	margin-top: 20px;
+	padding-left: 80px;
+	padding-right: 80px;
+	border-radius: 10px;
+	
+	/* reset this */
+	max-width: 60rem;
+}
+
+.dark main .h-full.flex-col > div > div
+{	
+	background: rgb(52,53,65);
+}
+
+main .h-full.flex-col > div.bg-gray-50
+{	
+	background: none; /* transparent it so we can see the background image */
+}
+
+/* override borders */
+main .h-full.flex-col > div
+{	
+	border: none;
+}
+
+/* Disregard spacer */
+main .h-full.flex-col > div:last-child
+{
+	visibility: hidden;
+}

--- a/src/themes/hacker.css
+++ b/src/themes/hacker.css
@@ -114,9 +114,34 @@ main .h-full.flex-col > div .prose
 }
 
 /* Disable Human/AI icons */
-main .h-full.flex-col > div > div > div.items-end:first-child
+main .h-full.flex-col > div > div > div.items-end:first-child div:first-child
 {	
 	display:none;
+}
+
+main .h-full.flex-col > div
+{	
+  position: relative;  
+}
+
+main .h-full.flex-col > div > div > div.items-end:first-child
+{	
+  position: absolute;
+  background-color: red;
+  left: 0px;
+  justify-content: left;
+}
+
+main .h-full.flex-col > div > div > div.items-end:first-child div.text-xs
+{	
+	position:absolute;
+  transform: 0 !important;
+  -webkit-transform: 0 !important;
+  justify-content: left;
+  justify-items: left;
+  top: -15px;
+  right: 50px;
+  visibility: visible !important;
 }
 
 .dark main .dark\:text-gray-400

--- a/src/themes/hacker.css
+++ b/src/themes/hacker.css
@@ -127,7 +127,6 @@ main .h-full.flex-col > div
 main .h-full.flex-col > div > div > div.items-end:first-child
 {	
   position: absolute;
-  background-color: red;
   left: 0px;
   justify-content: left;
 }

--- a/src/themes/hacker.css
+++ b/src/themes/hacker.css
@@ -1,0 +1,148 @@
+.dark main 
+{
+  background-color: black;
+}
+
+/* Disable all backgrounds for terminal theme */
+.dark main .dark\:bg-gray-800
+{
+  background: transparent;
+}
+
+main > div:last-child
+{
+	/* Disable that weird gradient */
+	background: transparent;
+}
+
+.dark main > div:last-child
+{
+	/* Disable that weird gradient */
+	background: transparent;
+}
+
+/* Style Input */
+main > div.absolute:last-child > form
+{
+	margin: 0;
+  max-width: 100%;
+  font-family: monospace;
+}
+
+main > div.absolute:last-child > div:last-child
+{
+	display:none;
+}
+
+main > div.absolute:last-child > form > div > div.flex.flex-col
+{
+	background-color: transparent;
+  box-shadow:none;
+  border:0;
+  border-bottom: 1px solid gray;
+  border-radius: 0;
+  color: white;
+  background-color: black;
+}
+
+main > div.absolute:last-child > form > div > div.flex.flex-col:before
+{
+	content:">";
+  position:absolute;
+  left:0px;
+  margin-top:-1px;
+  font-size: 16px;
+}
+
+.dark .btn-neutral
+{
+  background-color: #63ff44;
+  color: black;
+  border: none;
+}
+
+.dark main .bg-gray-800
+{
+  background-color: #63ff44;
+}
+
+.dark main .bg-gray-800.text-gray-200
+{
+  color: black;
+}
+
+main .h-full.flex-col > div
+{	
+	background: transparent; /* transparent it so we can see the background image */
+	/* Font */
+	font-family: monospace;
+	border:none;
+}
+
+main .h-full.flex-col > div > div
+{	
+	margin: 0;
+  margin-left: 1em;
+  padding-bottom:0;
+  max-width: 100%;
+}
+
+.dark main .h-full.flex-col > div
+{	
+  
+}
+
+/* Font Color */
+main .h-full.flex-col > div
+{
+  
+}
+
+.dark main .h-full.flex-col > div
+{
+  
+}
+
+main .h-full.flex-col > div .prose
+{	
+	color: black;
+}
+
+.dark main .h-full.flex-col > div .prose
+{	
+	color: #63ff44;
+}
+
+/* Disable Human/AI icons */
+main .h-full.flex-col > div > div > div.items-end:first-child
+{	
+	display:none;
+}
+
+.dark main .dark\:text-gray-400
+{
+  color:inherit;
+}
+
+.dark main .dark\:bg-gray-700
+{
+  background-color: #63ff44;
+  color:black;
+}
+
+.dark main .dark\:hover\:bg-gray-900:hover
+{
+  background-color: #4dc136;
+  color:black;
+}
+
+.dark main .dark\:bg-white\/5
+{
+  background-color: #63ff44;
+  color: black;
+}
+
+.dark main .dark\:text-gray-100
+{
+  color:#63ff44;
+}

--- a/src/themes/novel.css
+++ b/src/themes/novel.css
@@ -1,9 +1,6 @@
 /*
 	Novel themed CSS.
  */
- 
- 
-
 .prose 
 {
 	

--- a/src/themes/novel.css
+++ b/src/themes/novel.css
@@ -1,3 +1,68 @@
 /*
 	Novel themed CSS.
  */
+ 
+ 
+
+.prose 
+{
+	
+}
+
+/* Border */
+.border-b
+{
+	
+}
+
+/* Foolproof (TM) Individual Chat Node Selector */
+main .h-full.flex-col > div
+{
+	background: #fff;
+	box-shadow: 0 0 10px rgba(0,0,0,0.3);
+	
+	/* Font */
+	font-family: "Courier", "Times New Roman", serif;
+}
+
+/* Disregard spacer */
+main .h-full.flex-col > div:last-child
+{
+	visibility: hidden;
+}
+
+/*
+main.flex-col div:before, main
+
+.letter {
+  background: #fff;
+  box-shadow: 0 0 10px rgba(0,0,0,0.3);
+  margin: 26px auto 0;
+  max-width: 550px;
+  min-height: 300px;
+  padding: 24px;
+  position: relative;
+  width: 80%;
+}
+.letter:before, .letter:after {
+  content: "";
+  height: 98%;
+  position: absolute;
+  width: 100%;
+  z-index: -1;
+}
+.letter:before {
+  background: #fafafa;
+  box-shadow: 0 0 8px rgba(0,0,0,0.2);
+  left: -5px;
+  top: 4px;
+  transform: rotate(-2.5deg);
+}
+.letter:after {
+  background: #f6f6f6;
+  box-shadow: 0 0 3px rgba(0,0,0,0.2);
+  right: -3px;
+  top: 1px;
+  transform: rotate(1.4deg);
+}
+*/

--- a/src/themes/novel.css
+++ b/src/themes/novel.css
@@ -1,0 +1,3 @@
+/*
+	Novel themed CSS.
+ */

--- a/src/themes/sms.css
+++ b/src/themes/sms.css
@@ -10,7 +10,7 @@
 
 /* Foolproof (TM) Individual Chat Node Selector */
 main .h-full.flex-col > div
-{	
+{
 	border: 0;
 	background: transparent !important;
 	margin-top: 1rem;
@@ -18,49 +18,49 @@ main .h-full.flex-col > div
 }
 
 /* Make chats align left or right depending on if it's human or AI. Luckily we can assume odd/even. */
-main .h-full.flex-col > div:nth-child(odd) > div
-{	
+main .h-full.flex-col > div:nth-child(even) > div
+{
 	margin-left: 1rem;
   background-color: #E5E5EA;
 }
 
-.dark main .h-full.flex-col > div:nth-child(odd) > div
+.dark main .h-full.flex-col > div:nth-child(even) > div
 {
 	background-color: #333333;
 }
 
-main .h-full.flex-col > div:nth-child(even) > div
-{	
+main .h-full.flex-col > div:nth-child(odd) > div
+{
 	margin-right: 1rem;
-  background-color: #248BF5;
+    color: #E5E5EA;
+  background-color: #1982FC;
+}
+
+.lg\:w-\[calc\(100\%-115px\)\] {
+    width: calc(100% - 20px);
 }
 
 main .h-full.flex-col > div > div
-{	
+{
   border-radius: 1rem;
   padding: 0.5rem 0.75rem 0.5rem 0.75rem;
-}  
-
-.prose
-{
-	color: white;
 }
-  
+
 /* Disable Human/AI icons */
 main .h-full.flex-col > div > div > div.items-end:first-child div:first-child
-{	
+{
 	display:none;
 }
 
 /* Move the </> arrows */
-/* Yes, we do need to establish a new basis for absolutes. */ 
+/* Yes, we do need to establish a new basis for absolutes. */
 main .h-full.flex-col > div
-{	
-  position: relative;  
+{
+  position: relative;
 }
 
 main .h-full.flex-col > div > div > div.items-end:first-child
-{	
+{
   position: absolute; /* solely to remove it from the normal document flow */
   bottom: -10px;
   /* can't do left or right or else it breaks */
@@ -81,8 +81,8 @@ main .h-full.flex-col > div > div > div.items-end:first-child div.text-xs
 /* Move the thumbs up/thumbs down thingies, only for the AI */
 main .h-full.flex-col > div:nth-child(even) > div > div:last-child
 {
-	position: static;
-	width: 100%;
+    width: 100%;
+    position: static;
 }
 
 main .h-full.flex-col > div:nth-child(even) > div > div > div.self-end:last-child
@@ -96,16 +96,18 @@ main .h-full.flex-col > div:nth-child(even) > div > div > div.self-end:last-chil
   -webkit-transform: none !important;
 }
 
+
 main .h-full.flex-col > div:nth-child(even) > div > div > div > button
 {
   width: 24px;
   height: 24px;
+  margin-top: 25px;
 }
 
 /* Style Input */
 main > div.absolute:last-child > form
 {
-  
+
 }
 
 main > div.absolute:last-child > form > div > div.flex.flex-col

--- a/src/themes/sms.css
+++ b/src/themes/sms.css
@@ -1,0 +1,127 @@
+.dark main
+{
+	background: #1B1B1B;
+}
+
+.dark main .dark\:bg-gray-800
+{
+  background: transparent;
+}
+
+/* Foolproof (TM) Individual Chat Node Selector */
+main .h-full.flex-col > div
+{	
+	border: 0;
+	background: transparent !important;
+	margin-top: 1rem;
+	margin-bottom: 1rem;
+}
+
+/* Make chats align left or right depending on if it's human or AI. Luckily we can assume odd/even. */
+main .h-full.flex-col > div:nth-child(odd) > div
+{	
+	margin-left: 1rem;
+  background-color: #E5E5EA;
+}
+
+.dark main .h-full.flex-col > div:nth-child(odd) > div
+{
+	background-color: #333333;
+}
+
+main .h-full.flex-col > div:nth-child(even) > div
+{	
+	margin-right: 1rem;
+  background-color: #248BF5;
+}
+
+main .h-full.flex-col > div > div
+{	
+  border-radius: 1rem;
+  padding: 0.5rem 0.75rem 0.5rem 0.75rem;
+}  
+
+.prose
+{
+	color: white;
+}
+  
+/* Disable Human/AI icons */
+main .h-full.flex-col > div > div > div.items-end:first-child div:first-child
+{	
+	display:none;
+}
+
+/* Move the </> arrows */
+/* Yes, we do need to establish a new basis for absolutes. */ 
+main .h-full.flex-col > div
+{	
+  position: relative;  
+}
+
+main .h-full.flex-col > div > div > div.items-end:first-child
+{	
+  position: absolute; /* solely to remove it from the normal document flow */
+  bottom: -10px;
+  /* can't do left or right or else it breaks */
+  justify-content: left;
+}
+
+main .h-full.flex-col > div > div > div.items-end:first-child div.text-xs
+{
+  position:absolute;
+  transform: none !important;
+  -webkit-transform: none !important;
+  justify-content: left;
+  justify-items: left;
+  bottom: 0;
+  visibility: visible !important;
+}
+
+/* Move the thumbs up/thumbs down thingies, only for the AI */
+main .h-full.flex-col > div:nth-child(even) > div > div:last-child
+{
+	position: static;
+	width: 100%;
+}
+
+main .h-full.flex-col > div:nth-child(even) > div > div > div.self-end:last-child
+{
+  position: absolute;
+  top: -29px;
+  right: 1rem;
+  height: 24px;
+  /* dear transform: I hate you. */
+  transform: none !important;
+  -webkit-transform: none !important;
+}
+
+main .h-full.flex-col > div:nth-child(even) > div > div > div > button
+{
+  width: 24px;
+  height: 24px;
+}
+
+/* Style Input */
+main > div.absolute:last-child > form
+{
+  
+}
+
+main > div.absolute:last-child > form > div > div.flex.flex-col
+{
+  box-shadow: none;
+  border-radius: 2rem;
+}
+
+.dark main > div.absolute:last-child > form > div > div.flex.flex-col
+{
+	background: #333333;
+  border-color: #8B8E99;
+}
+
+.dark .btn-neutral
+{
+  background: #333333;
+  border-color: #8B8E99;
+}


### PR DESCRIPTION
Themes!

~Well, in reality there is one theme because I was too lazy to make more, but it works! Probably want to hold off releasing until we get at least 3 themes.~

There are now 3 themes!

~Also this defaults to the new theme system, but I don't want to be too pushy with an ancillary feature so probably disable default themes for release and let users discover it on their own.~

How it should look on firefox.
![image](https://user-images.githubusercontent.com/79041835/210391590-9ca8069f-46e6-43b5-86ea-ad03a0c1d4f3.png)

![image](https://user-images.githubusercontent.com/79041835/210567707-18d9fd2b-ba57-4beb-b166-60e401073da5.png)

![image](https://user-images.githubusercontent.com/79041835/211153750-d5b40ac6-55f8-4ebe-984f-8a28aafd3a4f.png)

If anything seems off, let me know because I have not tested this on chrome.

- Theme Injector!
- select themes from a `<select>` element!
    - yes, I was lazy in styling because `<select>` is notoriously hard to style cross-browser AND somebody at ChatGPT tried to style it themselves, without much luck. so I just reset it to be usable at first. if anything seems off, it's probably the result of OpenAI's styling which I didn't catch on firefox.
- themes can be loaded from files! they need to first be exposed through web accessible resources, but this makes creating and sharing themes much easier. see cozy-fireplace.css for an example. 
    - all theme files are pure css without changing the original HTML in anyway. it's a mess of css, but it should mostly work with a few edge cases.
    - also don't touch none.css as that is a hardcoded thing.
 - and I just realized... no, it doesn't work on thread.html because it relies on a whole bunch of hardcoded things. Ughh.