### PR TITLE
hotfix for scraper unified id bug

### DIFF
--- a/src/content-scripts/scraper.js
+++ b/src/content-scripts/scraper.js
@@ -374,7 +374,15 @@ function startScraper() {
                                     thread.title = title
                                 }
                             }
-                            t[getObjectIndexByID(id, t)] = thread
+							let threadIndex = getObjectIndexByID(id, t);
+							if(threadIndex !== null)
+							{
+								t[threadIndex] = thread;
+							}
+							else 
+							{
+								t.push(thread);
+							}
                         }
                         browser.storage.local.set({threads: t})
                     }


### PR DESCRIPTION
Fix for #92 
The cause is the scraper thinking a unified id has been updated in `t` when it has not.

This basically adds a check of paranoia: is the `thread` found in `t`? If not, then push.

This WILL likely cause double saving frequently, but better this than to lose data in my opinion. A more generalized fix is probably to prevent new non unified_ids from saving if it's not a previous convo, though since we have no way of detecting (and I don't think that we have anyone of connecting new ids with old ids), tis better just to disable new saving with non unified ids entirely since that's a whole heap of issues for exactly no benefit, unless I'm missing something.