### PR TITLE
Minor fixes 5

### DIFF
--- a/src/pages/js/prompts.js
+++ b/src/pages/js/prompts.js
@@ -187,8 +187,14 @@ Additional information:
 			else if (target.tagName === 'TEXTAREA'){
 				// Catchall
 			}
-			else {
+			else if (target.classList.contains('prompt')) {
 				toggle_prompt_editable(id, row);
+			}
+			else {
+				// if enabled, then disable
+				if(row.querySelector('textarea')){
+					toggle_prompt_editable(id, row);
+				}
 			}
 		});
 		prompt_text.addEventListener('keydown', (event) => {

--- a/src/pages/js/prompts.js
+++ b/src/pages/js/prompts.js
@@ -188,12 +188,7 @@ Additional information:
 				// Catchall
 			}
 			else {
-				if(row.querySelector('textarea')){
-					toggle_prompt_editable(id, row);
-				}
-				else{
-					use_prompt(id)
-				}
+				toggle_prompt_editable(id, row);
 			}
 		});
 		prompt_text.addEventListener('keydown', (event) => {

--- a/src/pages/js/prompts.js
+++ b/src/pages/js/prompts.js
@@ -198,11 +198,9 @@ Additional information:
 			}
 		});
 		prompt_text.addEventListener('keydown', (event) => {
-			if (event.key === 'Enter' && !event.shiftKey) {
-				if(!keys_pressed['shift'])
-				{
-					toggle_prompt_editable(id, row);
-				}
+			// if user presses ctrl-enter, then save.
+			if (event.key === 'Enter' && event.ctrlKey) {
+				toggle_prompt_editable(id, row);
 			}
 		});
 		main.appendChild(template);


### PR DESCRIPTION
See #124.

I do realize that UI changes are probably some of the worst changes to deal with because "they've changed it now!", but to be quite honest, this is for the sake of my sanity.

The reason I'm changing "enter" to "ctrl enter" is to match how it works if you edit an existing prompt on the main ChatGPT site itself. I've really gotten used to just pressing enter to start a new line. 

Hopefully this won't upset too many people. If we're really paranoid, probably add it as a toggle-able setting somewhere buried deep in the settings. Or if "ctrl-enter" is too weird, we can cut it out entirely, or let users define custom keys somewhere.