### PR TITLE
Themes rework: Fonts edition

### DIFF
--- a/manifests/mv2-manifest/manifest.json
+++ b/manifests/mv2-manifest/manifest.json
@@ -29,7 +29,7 @@
     }
   ],
   "web_accessible_resources" : ["content-scripts/prompts.js"
-    ,"themes/none.css","themes/cozy-fireplace.css","themes/hacker.css","themes/sms.css","themes/landscape-cycles.css","themes/terminal.css"],
+    ,"themes/none.css","themes/cozy-fireplace.css","themes/hacker.css","themes/sms.css","themes/landscape-cycles.css","themes/terminal.css","themes/paper.css"],
   "browser_action": {
     "default_title": "ChatGPT History"
   },

--- a/manifests/mv2-manifest/manifest.json
+++ b/manifests/mv2-manifest/manifest.json
@@ -29,6 +29,7 @@
     }
   ],
   "web_accessible_resources" : ["content-scripts/prompts.js"
+	,"fonts.css"
     ,"themes/none.css","themes/cozy-fireplace.css","themes/hacker.css","themes/sms.css","themes/landscape-cycles.css","themes/terminal.css","themes/paper.css"],
   "browser_action": {
     "default_title": "ChatGPT History"

--- a/manifests/mv3-manifest/manifest.json
+++ b/manifests/mv3-manifest/manifest.json
@@ -27,6 +27,7 @@
   ],
   "web_accessible_resources" : [{
     "resources": ["content-scripts/prompts.js"
+	  ,"fonts.css"
       ,"themes/none.css","themes/cozy-fireplace.css","themes/hacker.css","themes/sms.css","themes/landscape-cycles.css","themes/terminal.css","themes/paper.css"],
     "matches": ["https://chat.openai.com/*"],
     "use_dynamic_url": true

--- a/manifests/mv3-manifest/manifest.json
+++ b/manifests/mv3-manifest/manifest.json
@@ -27,7 +27,7 @@
   ],
   "web_accessible_resources" : [{
     "resources": ["content-scripts/prompts.js"
-      ,"themes/none.css","themes/cozy-fireplace.css","themes/hacker.css","themes/sms.css","themes/landscape-cycles.css","themes/terminal.css"],
+      ,"themes/none.css","themes/cozy-fireplace.css","themes/hacker.css","themes/sms.css","themes/landscape-cycles.css","themes/terminal.css","themes/paper.css"],
     "matches": ["https://chat.openai.com/*"],
     "use_dynamic_url": true
   }],

--- a/src/content-scripts/themes.js
+++ b/src/content-scripts/themes.js
@@ -2,7 +2,10 @@
 // remember to expose themes in web_accessible_resources
 // inject theme 
 const THEMES_LIST = ["paper.css", "sms.css", "cozy-fireplace.css","landscape-cycles.css", "hacker.css","terminal.css"];
+// use the same names as you would in css, because that's where it's going 
+const FONTS_LIST = ["Arial","Verdana","Times New Roman","Courier"];
 var currentTheme;
+var currentFont;
 var themeStylesheet;
 var fontStyle;
 
@@ -82,6 +85,7 @@ function createThemeSelectButton()
 	let wrapper = document.createElement("a");
 	wrapper.id = "theme-select-button";
 	wrapper.setAttribute("class", 'flex px-3 items-center gap-3 rounded-md hover:bg-gray-500/10 transition-colors duration-200 text-white cursor-pointer text-sm');
+	wrapper.style.height = "44px";
 	wrapper.innerHTML = `${icon}`;
 
 	document.head.insertAdjacentHTML("beforeend", `<style>select:focus{--tw-ring-shadow: none!important}</style>`)
@@ -152,7 +156,71 @@ function createThemeSelectButton()
 var fontSelectElement;
 function createFontSelectButton()
 {
+	let icon = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512" width="1em" height="1em" style="fill: white" stroke="currentColor"><!--! Font Awesome Pro 6.2.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license (Commercial License) Copyright 2022 Fonticons, Inc. --><path d="M254 52.8C249.3 40.3 237.3 32 224 32s-25.3 8.3-30 20.8L57.8 416H32c-17.7 0-32 14.3-32 32s14.3 32 32 32h96c17.7 0 32-14.3 32-32s-14.3-32-32-32h-1.8l18-48H303.8l18 48H320c-17.7 0-32 14.3-32 32s14.3 32 32 32h96c17.7 0 32-14.3 32-32s-14.3-32-32-32H390.2L254 52.8zM279.8 304H168.2L224 155.1 279.8 304z"/></svg>`;
 	
+	let wrapper = document.createElement("a");
+	wrapper.id = "font-select-button";
+	wrapper.setAttribute("class", 'flex px-3 items-center gap-3 rounded-md hover:bg-gray-500/10 transition-colors duration-200 text-white cursor-pointer text-sm');
+	wrapper.style.height = "44px";
+	wrapper.innerHTML = `${icon}`;
+	
+	let fontSelect = document.createElement("select");
+	fontSelect.style.background = "transparent";
+	fontSelect.style.height = "100%";
+	fontSelect.style.width = "100%";
+	fontSelect.style.paddingTop = "0.75rem";
+	fontSelect.style.paddingBottom = "0.75rem";
+	fontSelect.style.color = "inherit";
+	fontSelect.style.marginLeft= "-3%"; //align the select
+	fontSelect.style.fontFamily = "inherit";
+	fontSelect.style.fontSize = "inherit";
+	fontSelect.style.overflow = "visible";
+	fontSelect.style.border = "0";
+	
+	fontSelect.addEventListener("change", (event)=>
+	{
+		let fontFamily = fontSelect.value;
+		
+		if(fontFamily === "")
+		{
+			setFont(null);
+		}
+		else 
+		{
+			setFont(fontFamily);
+		}
+		
+		currentFont = fontFamily;
+	});
+	
+	let noFontOption = document.createElement("option");
+	noFontOption.value = "";
+	noFontOption.style.color = "black";
+	noFontOption.innerHTML = "Default";
+	fontSelect.appendChild(noFontOption);
+	
+	let fontsList = FONTS_LIST;
+	for(index = 0; index < fontsList.length; index++)
+	{
+		let fontOption = document.createElement("option");
+		fontOption.value = fontsList[index];
+		fontOption.style.color = "black";
+		fontOption.innerHTML = fontsList[index];
+		fontSelect.appendChild(fontOption);
+		
+		if(fontsList[index] === currentFont) 
+		{
+			// default selected 
+			fontOption.setAttribute("selected","true");
+		}
+	}
+	
+	wrapper.appendChild(fontSelect);
+	
+	var nav = document.querySelector("nav");
+	nav.appendChild(wrapper);
+	
+	fontSelectElement = wrapper;
 }
 
 /*
@@ -162,7 +230,7 @@ function readdThemeSelect()
 {
 	var nav = document.querySelector("nav");
 	nav.appendChild(themeSelectElement);
-	console.log("readding theme select.");
+	nav.appendChild(fontSelectElement);
 }
 
 // always place at the end because "let" statements can't be used before they're declared.
@@ -174,8 +242,5 @@ function initializeThemes()
 	
 	createThemeSelectButton();
 	createFontSelectButton();
-
-	setFont("Times New Roman");
-
 }
 initializeThemes();

--- a/src/content-scripts/themes.js
+++ b/src/content-scripts/themes.js
@@ -6,19 +6,29 @@ console.log(`Loading themes...`);
 const THEMES_LIST = ["paper.css", "sms.css", "cozy-fireplace.css","landscape-cycles.css", "hacker.css","terminal.css"];
 var currentTheme;
 var themeStylesheet;
+var fontStyle;
 
-function injectStyle(file)
+function injectStylesheet(file)
 {	
 	let head = document.querySelector('head');
     let stylesheet = document.createElement('link');
-	themeStylesheet = stylesheet;
     stylesheet.setAttribute('rel', 'stylesheet');
     stylesheet.setAttribute('type', 'text/css');
     stylesheet.setAttribute('href', file);
     head.appendChild(stylesheet);
+	return stylesheet;
 }
 
-injectStyle(browser.runtime.getURL('themes/none.css'));
+function injectStyle()
+{
+	let head = document.querySelector('head');
+    let style = document.createElement('style');
+    head.appendChild(style);
+	return style;
+}
+
+themeStylesheet = injectStylesheet(browser.runtime.getURL('themes/none.css'));
+fontStyle = injectStyle();
 
 browser.storage.local.get({"theme":"none.css"}, function(result)
 {
@@ -42,7 +52,22 @@ function changeTheme(theme)
 	themeStylesheet.setAttribute('href', browser.runtime.getURL(theme));
 }
 
-// theme selector
+function setFont(fontFamilyName)
+{
+	fontStyle.innerHTML = 
+`
+main {
+	font-family: "${fontFamilyName}";
+}
+main .h-full.flex-col > div {
+	font-family: "${fontFamilyName}";
+}
+`;
+}
+
+setFont("Times New Roman");
+
+// create theme selector
 let themeSelectElement;
 function addThemeSelectButton()
 {
@@ -116,8 +141,9 @@ function addThemeSelectButton()
 	
 	themeSelectElement = wrapper;
 }
-
 addThemeSelectButton();
+
+// create font selector
 
 /*
 	Re-add buttons hack.

--- a/src/content-scripts/themes.js
+++ b/src/content-scripts/themes.js
@@ -196,7 +196,7 @@ function createFontSelectButton()
 	let noFontOption = document.createElement("option");
 	noFontOption.value = "";
 	noFontOption.style.color = "black";
-	noFontOption.innerHTML = "Default";
+	noFontOption.innerHTML = "Default Font";
 	fontSelect.appendChild(noFontOption);
 	
 	let fontsList = FONTS_LIST;

--- a/src/content-scripts/themes.js
+++ b/src/content-scripts/themes.js
@@ -3,7 +3,7 @@ console.log(`Loading themes...`);
 // the way that themes work is to inject it after everything else.
 // remember to expose themes in web_accessible_resources
 // inject theme 
-const THEMES_LIST = ["cozy-fireplace.css","landscape-cycles.css", "sms.css", "hacker.css","terminal.css"];
+const THEMES_LIST = ["paper.css", "sms.css", "cozy-fireplace.css","landscape-cycles.css", "hacker.css","terminal.css"];
 var currentTheme;
 var themeStylesheet;
 

--- a/src/content-scripts/themes.js
+++ b/src/content-scripts/themes.js
@@ -3,7 +3,7 @@
 // inject theme 
 const THEMES_LIST = ["paper.css", "sms.css", "cozy-fireplace.css","landscape-cycles.css", "hacker.css","terminal.css"];
 // use the same names as you would in css, because that's where it's going 
-const FONTS_LIST = ["Arial","Verdana","Times New Roman","Courier"];
+const FONTS_LIST = ["Arial","Courier","Georgia","Times New Roman","Verdana"];
 var currentTheme;
 var currentFont;
 var themeStylesheet;

--- a/src/content-scripts/themes.js
+++ b/src/content-scripts/themes.js
@@ -1,5 +1,3 @@
-console.log(`Loading themes...`);
-
 // the way that themes work is to inject it after everything else.
 // remember to expose themes in web_accessible_resources
 // inject theme 
@@ -27,8 +25,6 @@ function injectStyle()
 	return style;
 }
 
-themeStylesheet = injectStylesheet(browser.runtime.getURL('themes/none.css'));
-fontStyle = injectStyle();
 
 browser.storage.local.get({"theme":"none.css"}, function(result)
 {
@@ -52,8 +48,18 @@ function changeTheme(theme)
 	themeStylesheet.setAttribute('href', browser.runtime.getURL(theme));
 }
 
+/*
+	Sets font by family name. 
+	@param fontFamilyName the font name you'd use in css. use null if you want to remove the font.
+ */
 function setFont(fontFamilyName)
 {
+	if(fontFamilyName === null)
+	{
+		fontStyle.innerHTML = "";
+	}
+	else 
+	{
 	fontStyle.innerHTML = 
 `
 main {
@@ -63,13 +69,13 @@ main .h-full.flex-col > div {
 	font-family: "${fontFamilyName}";
 }
 `;
+	}
 }
 
-setFont("Times New Roman");
 
 // create theme selector
-let themeSelectElement;
-function addThemeSelectButton()
+var themeSelectElement;
+function createThemeSelectButton()
 {
 	let icon = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" width="1em" height="1em" style="fill: white" stroke="currentColor" ><path d="M512 256c0 .9 0 1.8 0 2.7c-.4 36.5-33.6 61.3-70.1 61.3H344c-26.5 0-48 21.5-48 48c0 3.4 .4 6.7 1 9.9c2.1 10.2 6.5 20 10.8 29.9c6.1 13.8 12.1 27.5 12.1 42c0 31.8-21.6 60.7-53.4 62c-3.5 .1-7 .2-10.6 .2C114.6 512 0 397.4 0 256S114.6 0 256 0S512 114.6 512 256zM128 288c0-17.7-14.3-32-32-32s-32 14.3-32 32s14.3 32 32 32s32-14.3 32-32zm0-96c17.7 0 32-14.3 32-32s-14.3-32-32-32s-32 14.3-32 32s14.3 32 32 32zM288 96c0-17.7-14.3-32-32-32s-32 14.3-32 32s14.3 32 32 32s32-14.3 32-32zm96 96c17.7 0 32-14.3 32-32s-14.3-32-32-32s-32 14.3-32 32s14.3 32 32 32z"/></svg>`;
 	
@@ -141,9 +147,13 @@ function addThemeSelectButton()
 	
 	themeSelectElement = wrapper;
 }
-addThemeSelectButton();
 
 // create font selector
+var fontSelectElement;
+function createFontSelectButton()
+{
+	
+}
 
 /*
 	Re-add buttons hack.
@@ -152,4 +162,20 @@ function readdThemeSelect()
 {
 	var nav = document.querySelector("nav");
 	nav.appendChild(themeSelectElement);
+	console.log("readding theme select.");
 }
+
+// always place at the end because "let" statements can't be used before they're declared.
+function initializeThemes()
+{
+	console.log(`Loading themes...`);
+	themeStylesheet = injectStylesheet(browser.runtime.getURL('themes/none.css'));
+	fontStyle = injectStyle();
+	
+	createThemeSelectButton();
+	createFontSelectButton();
+
+	setFont("Times New Roman");
+
+}
+initializeThemes();

--- a/src/fonts.css
+++ b/src/fonts.css
@@ -1,0 +1,11 @@
+/**
+	Placeholder. To be used as a source of common fonts in future, but mostly useless right now.
+ */
+/*
+main {
+	font-family: [INSERT];
+}
+main .h-full.flex-col > div {
+	font-family: [INSERT];
+}
+ */

--- a/src/themes/cozy-fireplace.css
+++ b/src/themes/cozy-fireplace.css
@@ -44,11 +44,7 @@ main .h-full.flex-col
 /* Foolproof (TM) Individual Chat Node Selector */
 main .h-full.flex-col > div
 {	
-	background: none; /* transparent it so we can see the background image */
-	/* Font */
-	font-family: "Courier", "Times New Roman", serif;
-	
-	
+	background: none; /* transparent it so we can see the background image */	
 }
 
 main .h-full.flex-col > div > h1.text-center, /* Only select the ChatGPT main header */

--- a/src/themes/future-light.css
+++ b/src/themes/future-light.css
@@ -1,0 +1,58 @@
+/*
+	Retro future 2000s look. I could never get it right.
+ */
+
+/* Arial */
+/* #8D9DAF */
+
+/* Disable/override backgrounds */
+.dark main > div:first-child > div 
+{
+	background: transparent;
+}
+
+main .h-full.flex-col
+{
+	background: none;
+}
+
+main .h-full.flex-col > div.bg-gray-50
+{	
+	background: transparent; /* transparent it so we can see the background image */
+}
+
+.dark main .dark\:bg-gray-800
+{
+	background: transparent;
+}
+
+/* override borders */
+main .h-full.flex-col > div
+{	
+	border: none;
+}
+
+/* Disregard spacer without disabling its position in the layout. */
+main .h-full.flex-col > div:last-child
+{
+	visibility: hidden;
+}
+
+/* Disable that weird gradient for inputs */
+main > div.md\:bg-vert-light-gradient
+{
+	background: none;
+}
+
+/* Foolproof (TM) Individual Chat Node Selector */
+main .h-full.flex-col > div
+{
+	background: linear-gradient(0deg, hsla(0, 0%, 100%, 1) 0%, hsla(240, 24%, 92%, 1) 100%);
+  color: #8D9DAF;
+}
+
+main 
+{
+	background-color: white;
+	font-family: Arial;
+}

--- a/src/themes/paper.css
+++ b/src/themes/paper.css
@@ -19,6 +19,7 @@ main .h-full.flex-col > div.bg-gray-50
 	background: none; /* transparent it so we can see the background image */
 }
 */
+
 .dark main .dark\:bg-gray-800
 {
 	background: transparent;
@@ -46,6 +47,11 @@ main > div.md\:bg-vert-light-gradient
 main 
 {
   font-family: Courier;
+  /*
+  background: url(https://images.pexels.com/photos/733857/pexels-photo-733857.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=1);
+  background-size: cover;
+  background-repeat: no-repeat;
+  */
 }
 
 .text-base
@@ -56,10 +62,15 @@ main
 /* Foolproof (TM) Individual Chat Node Selector */
 main .h-full.flex-col > div
 {
+  background-color: #fff;
   position: relative;
   margin: 40px auto;
-  background: #fff;
   border-radius: 2px;
+}
+
+.dark main .h-full.flex-col > div
+{
+  background-color: #343541;
 }
 
 main .h-full.flex-col > div::before,

--- a/src/themes/paper.css
+++ b/src/themes/paper.css
@@ -1,0 +1,98 @@
+/* 
+	Credit to Martin Wolf
+	https://codepen.io/martinwolf/pen/GRaWPy
+ */
+
+/* Disable/override backgrounds */
+.dark main > div:first-child > div 
+{
+	background: transparent;
+}
+
+main .h-full.flex-col
+{
+	background: none;
+}
+/*
+main .h-full.flex-col > div.bg-gray-50
+{	
+	background: none; /* transparent it so we can see the background image */
+}
+*/
+.dark main .dark\:bg-gray-800
+{
+	background: transparent;
+}
+
+/* override borders */
+main .h-full.flex-col > div
+{	
+	border: none;
+}
+
+/* Disregard spacer without disabling its position in the layout. */
+main .h-full.flex-col > div:last-child
+{
+	visibility: hidden;
+}
+
+/* Disable that weird gradient for inputs */
+main > div.md\:bg-vert-light-gradient
+{
+	background: none;
+}
+
+/* END RESET */
+main 
+{
+  font-family: Courier;
+}
+
+.text-base
+{
+  font-size: 12pt;
+}
+
+/* Foolproof (TM) Individual Chat Node Selector */
+main .h-full.flex-col > div
+{
+  position: relative;
+  margin: 40px auto;
+  background: #fff;
+  border-radius: 2px;
+}
+
+main .h-full.flex-col > div::before,
+main .h-full.flex-col > div::after {
+  content: "";
+  position: absolute;
+  bottom: 10px;
+  width: 50%;
+  height: 20px;
+  box-shadow: 0 5px 16px rgba(0, 0, 0, 0.4);
+  z-index: -1;
+  transition: all 0.3s ease-in-out;
+}
+
+main .h-full.flex-col > div::before {
+  left: 5px;
+  transform: skew(-1deg) rotate(-1deg);
+}
+
+main .h-full.flex-col > div::after {
+  right: 5px;
+  transform: skew(1deg) rotate(1deg);
+}
+
+main .h-full.flex-col > div:hover::before,
+main .h-full.flex-col > div:hover::after {
+  box-shadow: 0 5px 18px rgba(0, 0, 0, 0.7);
+}
+
+main .h-full.flex-col > div:hover::before {
+  left: 15px;
+}
+
+main .h-full.flex-col > div:hover::after {
+  right: 15px;
+}

--- a/src/themes/template.css
+++ b/src/themes/template.css
@@ -36,3 +36,9 @@ main > div.md\:bg-vert-light-gradient
 {
 	background: none;
 }
+
+/* Foolproof (TM) Individual Chat Node Selector */
+main .h-full.flex-col > div
+{
+	
+}


### PR DESCRIPTION
The themes rework I've been threatening is now partially released.
- Right now it is taking up extra left floor space on the menu, but it's probably fine.
- New fonts! Now my bad taste in fonts can be easily remedied!
    - Note bene: themes may still come with their own unique fonts, but that's going to be the new default font for that particular theme. However, it is encouraged for many themes to refrain from having a particular font.
- Also removed the terrible font from cozy-fireplace.css because that's just me trying (and failing) to show off.
- Fonts are not saved for now for... reasons. Mostly because I don't want users to think their font choices is the default for new themes. 
- Paper.css is folded into this PR. If this PR is unsatisfactory, I suggest taking #132 instead. Conversely, that PR can be closed if this one is merged.

![image](https://user-images.githubusercontent.com/79041835/215010131-38249884-c0f9-4366-8bf8-77159cedf771.png)

PS: I notice now that I am writing much more like ChatGPT. It was inevitable.
