### PR TITLE
hacker.css rework

### DIFF
--- a/src/themes/hacker.css
+++ b/src/themes/hacker.css
@@ -83,6 +83,18 @@ main > div.absolute > form > div > div.flex.flex-col:before
   font-size: 16px;
 }
 
+.btn-neutral
+{
+  background-color: #05321e;
+  color: inherit;
+  border: none;
+}
+
+.btn-neutral:hover
+{
+  background-color: #15422e;
+}
+
 .dark .btn-neutral
 {
   background-color: #05321e;
@@ -109,7 +121,7 @@ main > div.absolute > form > div > div.flex.flex-col:before
 
 .dark main .bg-gray-800.text-gray-200
 {
-  color: black;
+  color: inherit;
 }
 
 main .h-full.flex-col > div
@@ -145,7 +157,7 @@ main .h-full.flex-col > div
 
 main .h-full.flex-col > div .prose
 {	
-	color: black;
+	color: inherit;
 }
 
 .dark main .h-full.flex-col > div .prose
@@ -183,9 +195,38 @@ main .h-full.flex-col > div > div > div.items-end:first-child div.text-xs
   visibility: visible !important;
 }
 
+.text-gray-800
+{
+  color: inherit;
+}
+
 .dark main .dark\:text-gray-400
 {
   color:inherit;
+}
+
+.bg-gray-50,
+.bg-gray-100
+{
+  background-color: #05321e;
+  color:inherit;
+}
+
+button.bg-gray-50:hover,
+button.bg-gray-100:hover
+{
+  background-color: #15422e;
+  color:inherit;
+}
+
+.text-gray-700
+{
+  color: inherit;
+}
+
+.text-gray-900
+{
+  color: white;
 }
 
 .dark main .dark\:bg-gray-700
@@ -208,4 +249,9 @@ main .h-full.flex-col > div > div > div.items-end:first-child div.text-xs
 .dark main .dark\:text-gray-100
 {
   color: inherit;
+}
+
+.md\:bg-vert-light-gradient
+{
+  background: none;
 }

--- a/src/themes/hacker.css
+++ b/src/themes/hacker.css
@@ -1,7 +1,35 @@
+/* 
+	CRT effect from Edwin
+	https://dev.to/ekeijl/retro-crt-terminal-screen-in-css-js-4afh
+	
+ */
+
 main
 {
   font-family: monospace;
+  background-image: radial-gradient( ellipse, #05321e 0%, #050505 90% );
+  animation: textShadow 4s infinite;
 }
+
+main .h-full.flex-col::before
+{
+  content: " ";
+	display: block;
+	position: absolute;
+	top: 0;
+	left: 0;
+	bottom: 0;
+	right: 0;
+	background: linear-gradient(
+		to bottom,
+		rgba(18, 16, 16, 0.1) 50%,
+		rgba(0, 0, 0, 0.25) 50%
+	);
+	background-size: 100% 8px;
+	z-index: 2;
+	pointer-events: none;
+}
+
 
 .dark main 
 {
@@ -172,4 +200,136 @@ main .h-full.flex-col > div > div > div.items-end:first-child div.text-xs
 .dark main .dark\:text-gray-100
 {
   color:#63ff44;
+}
+
+@keyframes flicker {
+  0% {
+    opacity: 0.27861;
+  }
+  5% {
+    opacity: 0.34769;
+  }
+  10% {
+    opacity: 0.23604;
+  }
+  15% {
+    opacity: 0.90626;
+  }
+  20% {
+    opacity: 0.18128;
+  }
+  25% {
+    opacity: 0.83891;
+  }
+  30% {
+    opacity: 0.65583;
+  }
+  35% {
+    opacity: 0.67807;
+  }
+  40% {
+    opacity: 0.26559;
+  }
+  45% {
+    opacity: 0.84693;
+  }
+  50% {
+    opacity: 0.96019;
+  }
+  55% {
+    opacity: 0.08594;
+  }
+  60% {
+    opacity: 0.20313;
+  }
+  65% {
+    opacity: 0.71988;
+  }
+  70% {
+    opacity: 0.53455;
+  }
+  75% {
+    opacity: 0.37288;
+  }
+  80% {
+    opacity: 0.71428;
+  }
+  85% {
+    opacity: 0.70419;
+  }
+  90% {
+    opacity: 0.7003;
+  }
+  95% {
+    opacity: 0.36108;
+  }
+  100% {
+    opacity: 0.24387;
+  }
+}
+
+@keyframes textShadow {
+  0% {
+    text-shadow: 0.4389924193300864px 0 1px rgba(0,30,255,0.5), -0.4389924193300864px 0 1px rgba(255,0,80,0.3), 0 0 3px;
+  }
+  5% {
+    text-shadow: 2.7928974010788217px 0 1px rgba(0,30,255,0.5), -2.7928974010788217px 0 1px rgba(255,0,80,0.3), 0 0 3px;
+  }
+  10% {
+    text-shadow: 0.02956275843481219px 0 1px rgba(0,30,255,0.5), -0.02956275843481219px 0 1px rgba(255,0,80,0.3), 0 0 3px;
+  }
+  15% {
+    text-shadow: 0.40218538552878136px 0 1px rgba(0,30,255,0.5), -0.40218538552878136px 0 1px rgba(255,0,80,0.3), 0 0 3px;
+  }
+  20% {
+    text-shadow: 3.4794037899852017px 0 1px rgba(0,30,255,0.5), -3.4794037899852017px 0 1px rgba(255,0,80,0.3), 0 0 3px;
+  }
+  25% {
+    text-shadow: 1.6125630401149584px 0 1px rgba(0,30,255,0.5), -1.6125630401149584px 0 1px rgba(255,0,80,0.3), 0 0 3px;
+  }
+  30% {
+    text-shadow: 0.7015590085143956px 0 1px rgba(0,30,255,0.5), -0.7015590085143956px 0 1px rgba(255,0,80,0.3), 0 0 3px;
+  }
+  35% {
+    text-shadow: 3.896914047650351px 0 1px rgba(0,30,255,0.5), -3.896914047650351px 0 1px rgba(255,0,80,0.3), 0 0 3px;
+  }
+  40% {
+    text-shadow: 3.870905614848819px 0 1px rgba(0,30,255,0.5), -3.870905614848819px 0 1px rgba(255,0,80,0.3), 0 0 3px;
+  }
+  45% {
+    text-shadow: 2.231056963361899px 0 1px rgba(0,30,255,0.5), -2.231056963361899px 0 1px rgba(255,0,80,0.3), 0 0 3px;
+  }
+  50% {
+    text-shadow: 0.08084290417898504px 0 1px rgba(0,30,255,0.5), -0.08084290417898504px 0 1px rgba(255,0,80,0.3), 0 0 3px;
+  }
+  55% {
+    text-shadow: 2.3758461067427543px 0 1px rgba(0,30,255,0.5), -2.3758461067427543px 0 1px rgba(255,0,80,0.3), 0 0 3px;
+  }
+  60% {
+    text-shadow: 2.202193051050636px 0 1px rgba(0,30,255,0.5), -2.202193051050636px 0 1px rgba(255,0,80,0.3), 0 0 3px;
+  }
+  65% {
+    text-shadow: 2.8638780614874975px 0 1px rgba(0,30,255,0.5), -2.8638780614874975px 0 1px rgba(255,0,80,0.3), 0 0 3px;
+  }
+  70% {
+    text-shadow: 0.48874025155497314px 0 1px rgba(0,30,255,0.5), -0.48874025155497314px 0 1px rgba(255,0,80,0.3), 0 0 3px;
+  }
+  75% {
+    text-shadow: 1.8948491305757957px 0 1px rgba(0,30,255,0.5), -1.8948491305757957px 0 1px rgba(255,0,80,0.3), 0 0 3px;
+  }
+  80% {
+    text-shadow: 0.0833037308038857px 0 1px rgba(0,30,255,0.5), -0.0833037308038857px 0 1px rgba(255,0,80,0.3), 0 0 3px;
+  }
+  85% {
+    text-shadow: 0.09769827255241735px 0 1px rgba(0,30,255,0.5), -0.09769827255241735px 0 1px rgba(255,0,80,0.3), 0 0 3px;
+  }
+  90% {
+    text-shadow: 3.443339761481782px 0 1px rgba(0,30,255,0.5), -3.443339761481782px 0 1px rgba(255,0,80,0.3), 0 0 3px;
+  }
+  95% {
+    text-shadow: 2.1841838852799786px 0 1px rgba(0,30,255,0.5), -2.1841838852799786px 0 1px rgba(255,0,80,0.3), 0 0 3px;
+  }
+  100% {
+    text-shadow: 2.6208764473832513px 0 1px rgba(0,30,255,0.5), -2.6208764473832513px 0 1px rgba(255,0,80,0.3), 0 0 3px;
+  }
 }

--- a/src/themes/hacker.css
+++ b/src/themes/hacker.css
@@ -3,16 +3,20 @@
 	https://dev.to/ekeijl/retro-crt-terminal-screen-in-css-js-4afh
 	
  */
+@import url("https://fonts.googleapis.com/css?family=VT323&display=swap");
 
 main
 {
-  font-family: monospace;
+  font-family: "VT323", monospace;
   background-image: radial-gradient( ellipse, #05321e 0%, #050505 90% );
-  animation: textShadow 4s infinite;
+  /* text glow */
+  text-shadow: 0 0 5px #c8c8c8;
+  color: #5bf870;
 }
 
 main .h-full.flex-col::before
 {
+  
   content: " ";
 	display: block;
 	position: absolute;
@@ -22,18 +26,12 @@ main .h-full.flex-col::before
 	right: 0;
 	background: linear-gradient(
 		to bottom,
-		rgba(18, 16, 16, 0.1) 50%,
+		rgba(18, 16, 16, 0.05) 50%,
 		rgba(0, 0, 0, 0.25) 50%
 	);
 	background-size: 100% 8px;
-	z-index: 2;
+	z-index: 0;
 	pointer-events: none;
-}
-
-
-.dark main 
-{
-  background-color: black;
 }
 
 /* Disable all backgrounds for terminal theme */
@@ -70,11 +68,10 @@ main > div.absolute > form > div > div.flex.flex-col
 {
 	background-color: transparent;
   box-shadow:none;
+  color: inherit;
   border:0;
   border-bottom: 1px solid gray;
   border-radius: 0;
-  color: white;
-  background-color: black;
 }
 
 main > div.absolute > form > div > div.flex.flex-col:before
@@ -88,14 +85,26 @@ main > div.absolute > form > div > div.flex.flex-col:before
 
 .dark .btn-neutral
 {
-  background-color: #63ff44;
-  color: black;
+  background-color: #05321e;
+  color: inherit;
   border: none;
+}
+
+.btn-primary
+{
+  background-color: #05321e;
+  color: inherit;
+}
+
+.btn-primary:hover
+{
+  background-color: #15422e;
+  color: inherit;
 }
 
 .dark main .bg-gray-800
 {
-  background-color: #63ff44;
+  background-color: #05321e;
 }
 
 .dark main .bg-gray-800.text-gray-200
@@ -141,7 +150,7 @@ main .h-full.flex-col > div .prose
 
 .dark main .h-full.flex-col > div .prose
 {	
-	color: #63ff44;
+	color: inherit;
 }
 
 /* Disable Human/AI icons */
@@ -181,155 +190,22 @@ main .h-full.flex-col > div > div > div.items-end:first-child div.text-xs
 
 .dark main .dark\:bg-gray-700
 {
-  background-color: #63ff44;
-  color:black;
+  background-color: #05321e;
+  color:inherit;
 }
 
 .dark main .dark\:hover\:bg-gray-900:hover
 {
-  background-color: #4dc136;
-  color:black;
+  background-color: #15422e;
 }
 
 .dark main .dark\:bg-white\/5
 {
-  background-color: #63ff44;
-  color: black;
+  background-color: #05321e;
+  color: inherit;
 }
 
 .dark main .dark\:text-gray-100
 {
-  color:#63ff44;
-}
-
-@keyframes flicker {
-  0% {
-    opacity: 0.27861;
-  }
-  5% {
-    opacity: 0.34769;
-  }
-  10% {
-    opacity: 0.23604;
-  }
-  15% {
-    opacity: 0.90626;
-  }
-  20% {
-    opacity: 0.18128;
-  }
-  25% {
-    opacity: 0.83891;
-  }
-  30% {
-    opacity: 0.65583;
-  }
-  35% {
-    opacity: 0.67807;
-  }
-  40% {
-    opacity: 0.26559;
-  }
-  45% {
-    opacity: 0.84693;
-  }
-  50% {
-    opacity: 0.96019;
-  }
-  55% {
-    opacity: 0.08594;
-  }
-  60% {
-    opacity: 0.20313;
-  }
-  65% {
-    opacity: 0.71988;
-  }
-  70% {
-    opacity: 0.53455;
-  }
-  75% {
-    opacity: 0.37288;
-  }
-  80% {
-    opacity: 0.71428;
-  }
-  85% {
-    opacity: 0.70419;
-  }
-  90% {
-    opacity: 0.7003;
-  }
-  95% {
-    opacity: 0.36108;
-  }
-  100% {
-    opacity: 0.24387;
-  }
-}
-
-@keyframes textShadow {
-  0% {
-    text-shadow: 0.4389924193300864px 0 1px rgba(0,30,255,0.5), -0.4389924193300864px 0 1px rgba(255,0,80,0.3), 0 0 3px;
-  }
-  5% {
-    text-shadow: 2.7928974010788217px 0 1px rgba(0,30,255,0.5), -2.7928974010788217px 0 1px rgba(255,0,80,0.3), 0 0 3px;
-  }
-  10% {
-    text-shadow: 0.02956275843481219px 0 1px rgba(0,30,255,0.5), -0.02956275843481219px 0 1px rgba(255,0,80,0.3), 0 0 3px;
-  }
-  15% {
-    text-shadow: 0.40218538552878136px 0 1px rgba(0,30,255,0.5), -0.40218538552878136px 0 1px rgba(255,0,80,0.3), 0 0 3px;
-  }
-  20% {
-    text-shadow: 3.4794037899852017px 0 1px rgba(0,30,255,0.5), -3.4794037899852017px 0 1px rgba(255,0,80,0.3), 0 0 3px;
-  }
-  25% {
-    text-shadow: 1.6125630401149584px 0 1px rgba(0,30,255,0.5), -1.6125630401149584px 0 1px rgba(255,0,80,0.3), 0 0 3px;
-  }
-  30% {
-    text-shadow: 0.7015590085143956px 0 1px rgba(0,30,255,0.5), -0.7015590085143956px 0 1px rgba(255,0,80,0.3), 0 0 3px;
-  }
-  35% {
-    text-shadow: 3.896914047650351px 0 1px rgba(0,30,255,0.5), -3.896914047650351px 0 1px rgba(255,0,80,0.3), 0 0 3px;
-  }
-  40% {
-    text-shadow: 3.870905614848819px 0 1px rgba(0,30,255,0.5), -3.870905614848819px 0 1px rgba(255,0,80,0.3), 0 0 3px;
-  }
-  45% {
-    text-shadow: 2.231056963361899px 0 1px rgba(0,30,255,0.5), -2.231056963361899px 0 1px rgba(255,0,80,0.3), 0 0 3px;
-  }
-  50% {
-    text-shadow: 0.08084290417898504px 0 1px rgba(0,30,255,0.5), -0.08084290417898504px 0 1px rgba(255,0,80,0.3), 0 0 3px;
-  }
-  55% {
-    text-shadow: 2.3758461067427543px 0 1px rgba(0,30,255,0.5), -2.3758461067427543px 0 1px rgba(255,0,80,0.3), 0 0 3px;
-  }
-  60% {
-    text-shadow: 2.202193051050636px 0 1px rgba(0,30,255,0.5), -2.202193051050636px 0 1px rgba(255,0,80,0.3), 0 0 3px;
-  }
-  65% {
-    text-shadow: 2.8638780614874975px 0 1px rgba(0,30,255,0.5), -2.8638780614874975px 0 1px rgba(255,0,80,0.3), 0 0 3px;
-  }
-  70% {
-    text-shadow: 0.48874025155497314px 0 1px rgba(0,30,255,0.5), -0.48874025155497314px 0 1px rgba(255,0,80,0.3), 0 0 3px;
-  }
-  75% {
-    text-shadow: 1.8948491305757957px 0 1px rgba(0,30,255,0.5), -1.8948491305757957px 0 1px rgba(255,0,80,0.3), 0 0 3px;
-  }
-  80% {
-    text-shadow: 0.0833037308038857px 0 1px rgba(0,30,255,0.5), -0.0833037308038857px 0 1px rgba(255,0,80,0.3), 0 0 3px;
-  }
-  85% {
-    text-shadow: 0.09769827255241735px 0 1px rgba(0,30,255,0.5), -0.09769827255241735px 0 1px rgba(255,0,80,0.3), 0 0 3px;
-  }
-  90% {
-    text-shadow: 3.443339761481782px 0 1px rgba(0,30,255,0.5), -3.443339761481782px 0 1px rgba(255,0,80,0.3), 0 0 3px;
-  }
-  95% {
-    text-shadow: 2.1841838852799786px 0 1px rgba(0,30,255,0.5), -2.1841838852799786px 0 1px rgba(255,0,80,0.3), 0 0 3px;
-  }
-  100% {
-    text-shadow: 2.6208764473832513px 0 1px rgba(0,30,255,0.5), -2.6208764473832513px 0 1px rgba(255,0,80,0.3), 0 0 3px;
-  }
+  color: inherit;
 }

--- a/src/themes/hacker.css
+++ b/src/themes/hacker.css
@@ -1,3 +1,8 @@
+main
+{
+  font-family: monospace;
+}
+
 .dark main 
 {
   background-color: black;
@@ -26,7 +31,6 @@ main > div.absolute > form
 {
 	margin: 0;
   max-width: 100%;
-  font-family: monospace;
 }
 
 main > div.absolute > div:last-child
@@ -75,7 +79,6 @@ main .h-full.flex-col > div
 {	
 	background: transparent; /* transparent it so we can see the background image */
 	/* Font */
-	font-family: monospace;
 	border:none;
 }
 

--- a/src/themes/paper.css
+++ b/src/themes/paper.css
@@ -46,7 +46,6 @@ main > div.md\:bg-vert-light-gradient
 /* END RESET */
 main 
 {
-  font-family: Courier;
   /*
   background: url(https://images.pexels.com/photos/733857/pexels-photo-733857.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=1);
   background-size: cover;


### PR DESCRIPTION
I am *finally* happy with hacker.css.
- the new hacker.css doesn't respect dark/light mode though, because... I was lazy. And honestly I can't think of a way to make it look good in light mode.
- hacker.css differentiates itself from terminal.css by being simulacrum. it is far more inspired by the matrix than by old IBM machines, and thus makes no attempts to be realistic.
- also removed Courier font from paper.css because honestly a default font is unnecessary for paper

![image](https://user-images.githubusercontent.com/79041835/215236262-7c8140f6-23be-41e8-bd20-9cf051887c8e.png)

Here is an example of the benefits of overriding base classes, as the circled thing is something which I literally didn't have to manually change. Also, an example of hacker.css in a more readable font.

![image](https://user-images.githubusercontent.com/79041835/215235890-b76d749a-47ba-4ea9-a0d0-bc8b8f094606.png)

Terminal in .net fonts may seem weird until you consider the fact that people have been using different fonts in terminals for years. And yes, I still cannot get over seeing dwarf fortress in a non pixel font.

![image](https://preview.redd.it/ps0kvhg1iwf41.png?width=960&crop=smart&auto=webp&s=fe64d54e1a21b3411a79838dd8f4fc618f4fafa8)