### PR TITLE
[Hotfix] fixed right click extension not working in firefox

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -1,4 +1,3 @@
-let browser;
 if (typeof browser === "undefined") {
     let settings;
     chrome.action.onClicked.addListener(function(tab) {
@@ -18,7 +17,7 @@ if (typeof browser === "undefined") {
             }
             chrome.tabs.create({url: url});
         });
-        });
+    });
     browser = chrome;
 }
 else {


### PR DESCRIPTION
hotfix for the extension not firing in firefox if you right clicked on the extension icon like it usually does.

`let browser` was overriding default browser namespace and making it undefined on firefox. I usually prefer the convention "isX" for flags to avoid these kinds of issues.