### PR TITLE
Custom CSS and Themes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+### v2.1.3
+- Overhauled theme buttons to a popup menu
+- Themes now save Fonts as well
+- Custom CSS theme editor 
+
 ### v2.1.2 [unreleased]
 
 - Fixed CORS bug for firefox export buttons.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ### v2.1.5 [unreleased]
 
-[add changes]
+- Overhauled theme buttons to a popup menu
+- Themes now save Fonts as well
+- Custom CSS theme editor 
 
 ### v2.1.4 - February 7, 2023 [hotfix]
 

--- a/src/content-scripts/export.js
+++ b/src/content-scripts/export.js
@@ -12,7 +12,7 @@ function check_url() {
 			{
 				type: "urlChange"
 			}, "*");
-		readdThemeSelect(); // just going to yoink this in here, from themes.js, as this is more convenient.
+		setTimeout(readdThemeSelect, 500);
         console.log("URL CHANGE")
     }
 }

--- a/src/content-scripts/themes.js
+++ b/src/content-scripts/themes.js
@@ -302,10 +302,9 @@ function createCustomStyleEditor()
 	//wrapper.style.visibility = "hidden";
 	
 	let container = document.createElement("div");
-	container.style.background = "white";
+	container.setAttribute("class", "flex flex-col items-center bg-gray-50 dark:bg-gray-800");
 	container.style.borderRadius = "1rem";
 	container.style.padding = "1rem";
-	container.setAttribute("class", "flex flex-col items-center");
 	wrapper.appendChild(container);
 	
 	let editorTitle = document.createElement("h1");
@@ -313,7 +312,7 @@ function createCustomStyleEditor()
 	container.appendChild(editorTitle);
 	
 	let editor = document.createElement("textarea");
-	editor.setAttribute("class", "mt-2");
+	editor.setAttribute("class", "mt-2 dark:bg-gray-800");
 	editor.setAttribute("cols","80");
 	editor.setAttribute("rows","25");
 	container.appendChild(editor);

--- a/src/content-scripts/themes.js
+++ b/src/content-scripts/themes.js
@@ -292,27 +292,59 @@ function createCustomStyleButton()
 var customStyleEditor;
 function createCustomStyleEditor()
 {
+	let wrapper = document.createElement("div");;
+	wrapper.setAttribute("class", "flex flex-col items-center h-full w-full");
+	wrapper.style.background = "rgba(25,25,25,0.7)";
+	wrapper.style.position = "fixed";
+	wrapper.style.top = 0;
+	wrapper.style.left = 0;
+	wrapper.style.justifyContent = "center";
+	//wrapper.style.visibility = "hidden";
+	
 	let container = document.createElement("div");
-	container.setAttribute("class", "flex flex-col items-center h-full w-full");
-	container.style.position = "fixed";
-	container.style.top = 0;
-	container.style.left = 0;
-	container.style.justifyContent = "center";
+	container.style.background = "white";
+	container.style.borderRadius = "1rem";
+	container.style.padding = "1rem";
+	container.setAttribute("class", "flex flex-col items-center");
+	wrapper.appendChild(container);
+	
+	let editorTitle = document.createElement("h1");
+	editorTitle.innerHTML = "Advanced Style Editor";
+	container.appendChild(editorTitle);
 	
 	let editor = document.createElement("textarea");
+	editor.setAttribute("class", "mt-2");
 	editor.setAttribute("cols","80");
 	editor.setAttribute("rows","25");
 	container.appendChild(editor);
 	
+	let buttonsContainer = document.createElement("div");
+	buttonsContainer.setAttribute("class", "text-center mt-2 flex justify-center");
+	container.appendChild(buttonsContainer);
+	
 	let saveChangesButton = document.createElement("button");
 	saveChangesButton.innerHTML = "Apply Changes";
-	saveChangesButton.setAttribute("class", "btn flex justify-center gap-2 btn-primary");
-	saveChangesButton.style.marginTop = "1rem";
-	container.appendChild(saveChangesButton);
+	saveChangesButton.setAttribute("class", "btn flex justify-center gap-2 btn-primary mr-2");
+	buttonsContainer.appendChild(saveChangesButton);
 	
-	document.body.appendChild(container);
+	saveChangesButton.addEventListener("click", function()
+	{
+		customStyle.innerHTML = editor.value;
+	});
 	
-	customStyleEditor = container;
+	let cancelButton = document.createElement("button");
+	cancelButton.innerHTML = "Cancel";
+	cancelButton.setAttribute("class", "btn flex justify-center gap-2 btn-neutral");
+	buttonsContainer.appendChild(cancelButton);
+	
+	cancelButton.addEventListener("click", function()
+	{
+		wrapper.style.visibility = "hidden";
+	});
+	
+	document.body.appendChild(wrapper);
+	
+	customStyleEditor = wrapper;
 }
 
 /*

--- a/src/content-scripts/themes.js
+++ b/src/content-scripts/themes.js
@@ -3,6 +3,11 @@
 const THEMES_LIST = ["paper.css", "sms.css", "cozy-fireplace.css","landscape-cycles.css", "hacker.css","terminal.css","rain.css"];
 // use the same names as you would in css, because that's where it's going 
 const FONTS_LIST = ["Arial","Courier","Georgia","Times New Roman","Verdana"];
+const SVG_ICONS = {
+	palette:`<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" width="1em" height="1em" style="fill: white" stroke="currentColor" ><path d="M512 256c0 .9 0 1.8 0 2.7c-.4 36.5-33.6 61.3-70.1 61.3H344c-26.5 0-48 21.5-48 48c0 3.4 .4 6.7 1 9.9c2.1 10.2 6.5 20 10.8 29.9c6.1 13.8 12.1 27.5 12.1 42c0 31.8-21.6 60.7-53.4 62c-3.5 .1-7 .2-10.6 .2C114.6 512 0 397.4 0 256S114.6 0 256 0S512 114.6 512 256zM128 288c0-17.7-14.3-32-32-32s-32 14.3-32 32s14.3 32 32 32s32-14.3 32-32zm0-96c17.7 0 32-14.3 32-32s-14.3-32-32-32s-32 14.3-32 32s14.3 32 32 32zM288 96c0-17.7-14.3-32-32-32s-32 14.3-32 32s14.3 32 32 32s32-14.3 32-32zm96 96c17.7 0 32-14.3 32-32s-14.3-32-32-32s-32 14.3-32 32s14.3 32 32 32z"/></svg>`,
+	font:`<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512" width="1em" height="1em" style="fill: white" stroke="currentColor"><!--! Font Awesome Pro 6.2.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license (Commercial License) Copyright 2022 Fonticons, Inc. --><path d="M254 52.8C249.3 40.3 237.3 32 224 32s-25.3 8.3-30 20.8L57.8 416H32c-17.7 0-32 14.3-32 32s14.3 32 32 32h96c17.7 0 32-14.3 32-32s-14.3-32-32-32h-1.8l18-48H303.8l18 48H320c-17.7 0-32 14.3-32 32s14.3 32 32 32h96c17.7 0 32-14.3 32-32s-14.3-32-32-32H390.2L254 52.8zM279.8 304H168.2L224 155.1 279.8 304z"/></svg>`,
+	code:`<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-braces" viewBox="0 0 16 16" width="1em" height="1em" style="fill: white" stroke="currentColor"><path d="M2.114 8.063V7.9c1.005-.102 1.497-.615 1.497-1.6V4.503c0-1.094.39-1.538 1.354-1.538h.273V2h-.376C3.25 2 2.49 2.759 2.49 4.352v1.524c0 1.094-.376 1.456-1.49 1.456v1.299c1.114 0 1.49.362 1.49 1.456v1.524c0 1.593.759 2.352 2.372 2.352h.376v-.964h-.273c-.964 0-1.354-.444-1.354-1.538V9.663c0-.984-.492-1.497-1.497-1.6zM13.886 7.9v.163c-1.005.103-1.497.616-1.497 1.6v1.798c0 1.094-.39 1.538-1.354 1.538h-.273v.964h.376c1.613 0 2.372-.759 2.372-2.352v-1.524c0-1.094.376-1.456 1.49-1.456V7.332c-1.114 0-1.49-.362-1.49-1.456V4.352C13.51 2.759 12.75 2 11.138 2h-.376v.964h.273c.964 0 1.354.444 1.354 1.538V6.3c0 .984.492 1.497 1.497 1.6z"/></svg>`,
+};
 var currentTheme;
 var currentFont;
 var themeStylesheet;
@@ -137,7 +142,7 @@ main .h-full.flex-col > div {
 var themeSelectElement;
 function createThemeSelectButton()
 {
-	let icon = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" width="1em" height="1em" style="fill: white" stroke="currentColor" ><path d="M512 256c0 .9 0 1.8 0 2.7c-.4 36.5-33.6 61.3-70.1 61.3H344c-26.5 0-48 21.5-48 48c0 3.4 .4 6.7 1 9.9c2.1 10.2 6.5 20 10.8 29.9c6.1 13.8 12.1 27.5 12.1 42c0 31.8-21.6 60.7-53.4 62c-3.5 .1-7 .2-10.6 .2C114.6 512 0 397.4 0 256S114.6 0 256 0S512 114.6 512 256zM128 288c0-17.7-14.3-32-32-32s-32 14.3-32 32s14.3 32 32 32s32-14.3 32-32zm0-96c17.7 0 32-14.3 32-32s-14.3-32-32-32s-32 14.3-32 32s14.3 32 32 32zM288 96c0-17.7-14.3-32-32-32s-32 14.3-32 32s14.3 32 32 32s32-14.3 32-32zm96 96c17.7 0 32-14.3 32-32s-14.3-32-32-32s-32 14.3-32 32s14.3 32 32 32z"/></svg>`;
+	let icon = SVG_ICONS.palette;
 	
 	let wrapper = document.createElement("a");
 	wrapper.id = "theme-select-button";
@@ -213,7 +218,7 @@ function createThemeSelectButton()
 var fontSelectElement;
 function createFontSelectButton()
 {
-	let icon = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512" width="1em" height="1em" style="fill: white" stroke="currentColor"><!--! Font Awesome Pro 6.2.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license (Commercial License) Copyright 2022 Fonticons, Inc. --><path d="M254 52.8C249.3 40.3 237.3 32 224 32s-25.3 8.3-30 20.8L57.8 416H32c-17.7 0-32 14.3-32 32s14.3 32 32 32h96c17.7 0 32-14.3 32-32s-14.3-32-32-32h-1.8l18-48H303.8l18 48H320c-17.7 0-32 14.3-32 32s14.3 32 32 32h96c17.7 0 32-14.3 32-32s-14.3-32-32-32H390.2L254 52.8zM279.8 304H168.2L224 155.1 279.8 304z"/></svg>`;
+	let icon = SVG_ICONS.font;
 	
 	let wrapper = document.createElement("a");
 	wrapper.id = "font-select-button";
@@ -281,7 +286,12 @@ function createFontSelectButton()
 var customStyleButton;
 function createCustomStyleButton()
 {
+	let icon = SVG_ICONS.code;
 	
+	let wrapper = createButton(icon, "Advanced Style");
+	wrapper.addEventListener("click", ()=>{customStyleEditor.style.visibility = "visible"});
+	
+	customStyleButton = wrapper;
 }
 
 var customStyleEditor;
@@ -305,6 +315,19 @@ function createCustomStyleEditor()
 	let editorTitle = document.createElement("h1");
 	editorTitle.innerHTML = "Advanced Style Editor";
 	container.appendChild(editorTitle);
+	
+	let editorInfo = document.createElement("p");
+	editorInfo.innerHTML = `Add some custom CSS which will be injected after everything else. For example, try changing the background color using`;
+	container.appendChild(editorInfo);
+	
+	let editorCodeExample = document.createElement("code");
+	editorCodeExample.innerHTML = `<code>main .h-full.flex-col > div
+{
+	background-color: red;
+}</code>`;
+	editorCodeExample.style.width = `100%`;
+	editorCodeExample.style.whiteSpace = `break-spaces`;
+	container.appendChild(editorCodeExample);
 	
 	let editor = document.createElement("textarea");
 	editor.setAttribute("class", "mt-2 dark:bg-gray-800");
@@ -335,8 +358,6 @@ function createCustomStyleEditor()
 	{
 		customStyleEditor.style.visibility = "hidden";
 	});
-	
-	document.body.appendChild(wrapper);
 	
 	customStyleEditor = wrapper;
 }
@@ -374,7 +395,7 @@ var menuThemeEditorElement;
 function createMenuThemeEditor()
 {
 	let wrapper = document.createElement("div");
-	wrapper.setAttribute("class", 'flex flex-col items-center bg-gray-900 text-white');
+	wrapper.setAttribute("class", 'flex flex-col items-center bg-gray-900 text-white space-y-1 p-2');
 	wrapper.style.width = "260px"; // same width as the left menu bar
 	wrapper.style.position = "absolute"; 
 	wrapper.style.left = "100%";
@@ -400,6 +421,7 @@ function createMenuThemeEditor()
 	// append buttons 
 	menuThemeEditorElement.appendChild(themeSelectElement);
 	menuThemeEditorElement.appendChild(fontSelectElement);
+	menuThemeEditorElement.appendChild(customStyleButton);
 	
 	closeMenuThemeEditor();
 }
@@ -426,6 +448,22 @@ function toggleMenuThemeEditor()
 	}
 }
 
+/**
+	Button boilerplate.
+	Does not do an onclick.
+ */
+function createButton(iconHTML, buttonText)
+{
+	let button = document.createElement("a");
+	button.setAttribute("class", 'flex px-3 items-center gap-3 rounded-md hover:bg-gray-500/10 transition-colors duration-200 text-white cursor-pointer text-sm');
+	button.style.height = "44px";
+	button.style.width = "244px";
+	
+	button.innerHTML = `${iconHTML} ${buttonText}`;
+	
+	return button;
+}
+
 /*
 	Re-add buttons hack.
  */
@@ -443,9 +481,13 @@ function initializeThemes()
 	fontStyle = injectStyle();
 	themeStyle = injectStyle();
 	customStyle = injectStyle();
-
+	
+	createCustomStyleEditor();
+	document.body.appendChild(customStyleEditor);
+	
 	createThemeSelectButton();
 	createFontSelectButton();
+	createCustomStyleButton();
 	createMenuThemeEditorButton();
 	
 	readdThemeSelect();

--- a/src/content-scripts/themes.js
+++ b/src/content-scripts/themes.js
@@ -350,7 +350,7 @@ function createCustomStyleEditor()
 	Create menu theme editor that opens to the right.
  */
 var menuThemeEditorButton;
-function createMenuThemeEditor()
+function createMenuThemeEditorButton()
 {
 	let icon = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" width="1em" height="1em" style="fill: white" stroke="currentColor" ><path d="M512 256c0 .9 0 1.8 0 2.7c-.4 36.5-33.6 61.3-70.1 61.3H344c-26.5 0-48 21.5-48 48c0 3.4 .4 6.7 1 9.9c2.1 10.2 6.5 20 10.8 29.9c6.1 13.8 12.1 27.5 12.1 42c0 31.8-21.6 60.7-53.4 62c-3.5 .1-7 .2-10.6 .2C114.6 512 0 397.4 0 256S114.6 0 256 0S512 114.6 512 256zM128 288c0-17.7-14.3-32-32-32s-32 14.3-32 32s14.3 32 32 32s32-14.3 32-32zm0-96c17.7 0 32-14.3 32-32s-14.3-32-32-32s-32 14.3-32 32s14.3 32 32 32zM288 96c0-17.7-14.3-32-32-32s-32 14.3-32 32s14.3 32 32 32s32-14.3 32-32zm96 96c17.7 0 32-14.3 32-32s-14.3-32-32-32s-32 14.3-32 32s14.3 32 32 32z"/></svg>`;
 	
@@ -369,11 +369,33 @@ function createMenuThemeEditor()
 	wrapper.appendChild(button);
 	
 	button.addEventListener("click", ()=>{openMenuThemeEditor()});
-		
+	
 	var nav = document.querySelector("nav");
 	nav.appendChild(wrapper);
 	
 	menuThemeEditorButton = wrapper;
+	
+	// create the editor itself
+	createMenuThemeEditor();
+}
+
+var menuThemeEditorElement;
+function createMenuThemeEditor()
+{
+	let wrapper = document.createElement("div");
+	wrapper.setAttribute("class", 'flex items-center bg-gray-900 text-white');
+	wrapper.style.width = "260px"; // same width as the left menu bar
+	wrapper.style.position = "absolute"; 
+	wrapper.style.left = "100%";
+	wrapper.style.bottom = "0";
+	
+	let title = document.createElement("h1");
+	title.innerHTML = "Theme Editor";
+	wrapper.appendChild(title);
+	
+	menuThemeEditorButton.appendChild(wrapper);
+	
+	menuThemeEditorElement = wrapper;
 }
 
 function openMenuThemeEditor()
@@ -397,9 +419,9 @@ function toggleMenuThemeEditor()
 function readdThemeSelect()
 {
 	var nav = document.querySelector("nav");
+	nav.appendChild(menuThemeEditorButton);
 	nav.appendChild(themeSelectElement);
 	nav.appendChild(fontSelectElement);
-	nav.appendChild(menuThemeEditorButton);
 	
 	let button_class = 'flex py-3 px-3 items-center gap-3 rounded-md hover:bg-gray-500/10 transition-colors duration-200 text-white cursor-pointer text-sm';
 }
@@ -416,6 +438,6 @@ function initializeThemes()
 	createThemeSelectButton();
 	createFontSelectButton();
 	createCustomStyleEditor();
-	createMenuThemeEditor();
+	createMenuThemeEditorButton();
 }
 initializeThemes();

--- a/src/content-scripts/themes.js
+++ b/src/content-scripts/themes.js
@@ -8,6 +8,8 @@ var currentFont;
 var themeStylesheet;
 var themeStyle;
 var fontStyle;
+var customStylesheet;
+var customStyle;
 var themeAudio;
 
 function injectStylesheet(file)
@@ -55,6 +57,13 @@ browser.storage.local.get({"theme":"none.css"}, function(result)
 			option.setAttribute("selected","true");
 		}
 	}
+});
+
+// let users inject arbitrary CSS, what could go wrong?
+// at least it's not JS so there probably aren't any exploits, and it's their own machine so they can do what they wish
+browser.storage.local.get({"custom_style":""}, function(result)
+{
+	
 });
 
 function changeTheme(theme, onload=false)
@@ -273,6 +282,39 @@ function createFontSelectButton()
 	fontSelectElement = wrapper;
 }
 
+// create custom style button that click opens the editor box
+var customStyleButton;
+function createCustomStyleButton()
+{
+	
+}
+
+var customStyleEditor;
+function createCustomStyleEditor()
+{
+	let container = document.createElement("div");
+	container.setAttribute("class", "flex flex-col items-center h-full w-full");
+	container.style.position = "fixed";
+	container.style.top = 0;
+	container.style.left = 0;
+	container.style.justifyContent = "center";
+	
+	let editor = document.createElement("textarea");
+	editor.setAttribute("cols","80");
+	editor.setAttribute("rows","25");
+	container.appendChild(editor);
+	
+	let saveChangesButton = document.createElement("button");
+	saveChangesButton.innerHTML = "Apply Changes";
+	saveChangesButton.setAttribute("class", "btn flex justify-center gap-2 btn-primary");
+	saveChangesButton.style.marginTop = "1rem";
+	container.appendChild(saveChangesButton);
+	
+	document.body.appendChild(container);
+	
+	customStyleEditor = container;
+}
+
 /*
 	Re-add buttons hack.
  */
@@ -290,8 +332,10 @@ function initializeThemes()
 	themeStylesheet = injectStylesheet(browser.runtime.getURL('themes/none.css'));
 	fontStyle = injectStyle();
 	themeStyle = injectStyle();
+	customStyle = injectStyle();
 
-	createThemeSelectButton()
-	createFontSelectButton()
+	createThemeSelectButton();
+	createFontSelectButton();
+	createCustomStyleEditor();
 }
 initializeThemes();

--- a/src/content-scripts/themes.js
+++ b/src/content-scripts/themes.js
@@ -370,7 +370,7 @@ function createCustomStyleEditor()
 	let editorCodeExample = document.createElement("code");
 	editorCodeExample.innerHTML = `<code>main .h-full.flex-col > div
 {
-	background-color: red;
+    background-color: red;
 }</code>`;
 	editorCodeExample.style.width = `100%`;
 	editorCodeExample.style.whiteSpace = `break-spaces`;

--- a/src/content-scripts/themes.js
+++ b/src/content-scripts/themes.js
@@ -204,11 +204,12 @@ function createThemeSelectButton()
 	}
 	
 	wrapper.appendChild(themeSelect);
-	
+	/*
 	var nav = document.querySelector("nav");
 	nav.appendChild(wrapper);
-	
+	 */
 	themeSelectElement = wrapper;
+	return wrapper;
 }
 
 // create font selector
@@ -275,10 +276,10 @@ function createFontSelectButton()
 	}
 	
 	wrapper.appendChild(fontSelect);
-	
+	/*
 	var nav = document.querySelector("nav");
 	nav.appendChild(wrapper);
-	
+	*/
 	fontSelectElement = wrapper;
 }
 
@@ -369,10 +370,10 @@ function createMenuThemeEditorButton()
 	wrapper.appendChild(button);
 	
 	button.addEventListener("click", ()=>{openMenuThemeEditor()});
-	
+	/*
 	var nav = document.querySelector("nav");
 	nav.appendChild(wrapper);
-	
+	 */
 	menuThemeEditorButton = wrapper;
 	
 	// create the editor itself
@@ -383,19 +384,23 @@ var menuThemeEditorElement;
 function createMenuThemeEditor()
 {
 	let wrapper = document.createElement("div");
-	wrapper.setAttribute("class", 'flex items-center bg-gray-900 text-white');
+	wrapper.setAttribute("class", 'flex flex-col items-center bg-gray-900 text-white');
 	wrapper.style.width = "260px"; // same width as the left menu bar
 	wrapper.style.position = "absolute"; 
 	wrapper.style.left = "100%";
 	wrapper.style.bottom = "0";
 	
 	let title = document.createElement("h1");
-	title.innerHTML = "Theme Editor";
+	title.innerHTML = "Theme Settings";
 	wrapper.appendChild(title);
 	
 	menuThemeEditorButton.appendChild(wrapper);
 	
 	menuThemeEditorElement = wrapper;
+	
+	// append buttons 
+	menuThemeEditorElement.appendChild(themeSelectElement);
+	menuThemeEditorElement.appendChild(fontSelectElement);
 }
 
 function openMenuThemeEditor()
@@ -420,10 +425,6 @@ function readdThemeSelect()
 {
 	var nav = document.querySelector("nav");
 	nav.appendChild(menuThemeEditorButton);
-	nav.appendChild(themeSelectElement);
-	nav.appendChild(fontSelectElement);
-	
-	let button_class = 'flex py-3 px-3 items-center gap-3 rounded-md hover:bg-gray-500/10 transition-colors duration-200 text-white cursor-pointer text-sm';
 }
 
 // always place at the end because "let" statements can't be used before they're declared.
@@ -437,7 +438,8 @@ function initializeThemes()
 
 	createThemeSelectButton();
 	createFontSelectButton();
-	createCustomStyleEditor();
 	createMenuThemeEditorButton();
+	
+	readdThemeSelect();
 }
 initializeThemes();

--- a/src/content-scripts/themes.js
+++ b/src/content-scripts/themes.js
@@ -328,7 +328,9 @@ function createCustomStyleButton()
 		browser.storage.local.get({"theme":{}}, (result) =>
 		{
 			let themeSettings = result.theme;
-			let customCSS = themeSettings?.customCSS; 
+			let customCSS = themeSettings?.customCSS;
+			
+			if(customCSS === undefined) customCSS = "";
 			
 			customStyleEditor.querySelector("textarea").value = customCSS;
 		});

--- a/src/content-scripts/themes.js
+++ b/src/content-scripts/themes.js
@@ -299,7 +299,7 @@ function createCustomStyleEditor()
 	wrapper.style.top = 0;
 	wrapper.style.left = 0;
 	wrapper.style.justifyContent = "center";
-	//wrapper.style.visibility = "hidden";
+	wrapper.style.visibility = "hidden"; // default to hidden for the modal
 	
 	let container = document.createElement("div");
 	container.setAttribute("class", "flex flex-col items-center bg-gray-50 dark:bg-gray-800");
@@ -338,12 +338,57 @@ function createCustomStyleEditor()
 	
 	cancelButton.addEventListener("click", function()
 	{
-		wrapper.style.visibility = "hidden";
+		customStyleEditor.style.visibility = "hidden";
 	});
 	
 	document.body.appendChild(wrapper);
 	
 	customStyleEditor = wrapper;
+}
+
+/*
+	Create menu theme editor that opens to the right.
+ */
+var menuThemeEditorButton;
+function createMenuThemeEditor()
+{
+	let icon = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" width="1em" height="1em" style="fill: white" stroke="currentColor" ><path d="M512 256c0 .9 0 1.8 0 2.7c-.4 36.5-33.6 61.3-70.1 61.3H344c-26.5 0-48 21.5-48 48c0 3.4 .4 6.7 1 9.9c2.1 10.2 6.5 20 10.8 29.9c6.1 13.8 12.1 27.5 12.1 42c0 31.8-21.6 60.7-53.4 62c-3.5 .1-7 .2-10.6 .2C114.6 512 0 397.4 0 256S114.6 0 256 0S512 114.6 512 256zM128 288c0-17.7-14.3-32-32-32s-32 14.3-32 32s14.3 32 32 32s32-14.3 32-32zm0-96c17.7 0 32-14.3 32-32s-14.3-32-32-32s-32 14.3-32 32s14.3 32 32 32zM288 96c0-17.7-14.3-32-32-32s-32 14.3-32 32s14.3 32 32 32s32-14.3 32-32zm96 96c17.7 0 32-14.3 32-32s-14.3-32-32-32s-32 14.3-32 32s14.3 32 32 32z"/></svg>`;
+	
+	let wrapper = document.createElement("div");
+	wrapper.id = "menu-theme-editor-button";
+	// wrapper.setAttribute("class", 'flex px-3 items-center gap-3 rounded-md hover:bg-gray-500/10 transition-colors duration-200 text-white cursor-pointer text-sm');
+	wrapper.style.height = "44px";
+	wrapper.style.padding = "0";
+	// wrapper.style.position = "relative";
+	
+	let button = document.createElement("a");
+	button.setAttribute("class", 'flex px-3 items-center gap-3 rounded-md hover:bg-gray-500/10 transition-colors duration-200 text-white cursor-pointer text-sm');
+	button.style.width = "100%";
+	button.style.height = "100%";
+	button.innerHTML = `${icon} Theme Settings`;
+	wrapper.appendChild(button);
+	
+	button.addEventListener("click", ()=>{openMenuThemeEditor()});
+		
+	var nav = document.querySelector("nav");
+	nav.appendChild(wrapper);
+	
+	menuThemeEditorButton = wrapper;
+}
+
+function openMenuThemeEditor()
+{
+	console.log(`ACK`);
+}
+
+function closeMenuThemeEditor()
+{
+	
+}
+
+function toggleMenuThemeEditor()
+{
+	
 }
 
 /*
@@ -354,6 +399,9 @@ function readdThemeSelect()
 	var nav = document.querySelector("nav");
 	nav.appendChild(themeSelectElement);
 	nav.appendChild(fontSelectElement);
+	nav.appendChild(menuThemeEditorButton);
+	
+	let button_class = 'flex py-3 px-3 items-center gap-3 rounded-md hover:bg-gray-500/10 transition-colors duration-200 text-white cursor-pointer text-sm';
 }
 
 // always place at the end because "let" statements can't be used before they're declared.
@@ -368,5 +416,6 @@ function initializeThemes()
 	createThemeSelectButton();
 	createFontSelectButton();
 	createCustomStyleEditor();
+	createMenuThemeEditor();
 }
 initializeThemes();

--- a/src/content-scripts/themes.js
+++ b/src/content-scripts/themes.js
@@ -469,7 +469,7 @@ function createMenuThemeEditor()
 	// append buttons 
 	menuThemeEditorElement.appendChild(themeSelectElement);
 	menuThemeEditorElement.appendChild(fontSelectElement);
-	menuThemeEditorElement.appendChild(customStyleButton);
+	//menuThemeEditorElement.appendChild(customStyleButton);
 	
 	closeMenuThemeEditor();
 }

--- a/src/content-scripts/themes.js
+++ b/src/content-scripts/themes.js
@@ -143,6 +143,7 @@ function createThemeSelectButton()
 	wrapper.id = "theme-select-button";
 	wrapper.setAttribute("class", 'flex px-3 items-center gap-3 rounded-md hover:bg-gray-500/10 transition-colors duration-200 text-white cursor-pointer text-sm');
 	wrapper.style.height = "44px";
+	wrapper.style.width = "244px";
 	wrapper.innerHTML = `${icon}`;
 
 	document.head.insertAdjacentHTML("beforeend", `<style>select:focus{--tw-ring-shadow: none!important}</style>`)
@@ -204,10 +205,6 @@ function createThemeSelectButton()
 	}
 	
 	wrapper.appendChild(themeSelect);
-	/*
-	var nav = document.querySelector("nav");
-	nav.appendChild(wrapper);
-	 */
 	themeSelectElement = wrapper;
 	return wrapper;
 }
@@ -222,6 +219,7 @@ function createFontSelectButton()
 	wrapper.id = "font-select-button";
 	wrapper.setAttribute("class", 'flex px-3 items-center gap-3 rounded-md hover:bg-gray-500/10 transition-colors duration-200 text-white cursor-pointer text-sm');
 	wrapper.style.height = "44px";
+	wrapper.style.width = "244px";
 	wrapper.innerHTML = `${icon}`;
 	
 	let fontSelect = document.createElement("select");
@@ -276,10 +274,6 @@ function createFontSelectButton()
 	}
 	
 	wrapper.appendChild(fontSelect);
-	/*
-	var nav = document.querySelector("nav");
-	nav.appendChild(wrapper);
-	*/
 	fontSelectElement = wrapper;
 }
 
@@ -369,11 +363,7 @@ function createMenuThemeEditorButton()
 	button.innerHTML = `${icon} Theme Settings`;
 	wrapper.appendChild(button);
 	
-	button.addEventListener("click", ()=>{openMenuThemeEditor()});
-	/*
-	var nav = document.querySelector("nav");
-	nav.appendChild(wrapper);
-	 */
+	button.addEventListener("click", ()=>{toggleMenuThemeEditor()});
 	menuThemeEditorButton = wrapper;
 	
 	// create the editor itself
@@ -390,9 +380,18 @@ function createMenuThemeEditor()
 	wrapper.style.left = "100%";
 	wrapper.style.bottom = "0";
 	
+	let titleContainer = document.createElement("div");
+	titleContainer.setAttribute("class", 'border-b border-white/20 w-full px-3');
+	titleContainer.style.height = "44px"; // same height as buttons
+	wrapper.appendChild(titleContainer);
+	
 	let title = document.createElement("h1");
 	title.innerHTML = "Theme Settings";
-	wrapper.appendChild(title);
+	// title.style.padding = "12px";
+	title.style.fontSize = "1em";
+	title.style.fontWeight = "normal";
+	title.style.textAlign = "center";
+	titleContainer.appendChild(title);
 	
 	menuThemeEditorButton.appendChild(wrapper);
 	
@@ -401,21 +400,30 @@ function createMenuThemeEditor()
 	// append buttons 
 	menuThemeEditorElement.appendChild(themeSelectElement);
 	menuThemeEditorElement.appendChild(fontSelectElement);
+	
+	closeMenuThemeEditor();
 }
 
 function openMenuThemeEditor()
 {
-	console.log(`ACK`);
+	menuThemeEditorElement.style.visibility = "visible";
 }
 
 function closeMenuThemeEditor()
 {
-	
+	menuThemeEditorElement.style.visibility = "hidden";
 }
 
 function toggleMenuThemeEditor()
 {
-	
+	if(menuThemeEditorElement.style.visibility === "visible")
+	{
+		closeMenuThemeEditor();
+	}
+	else 
+	{
+		openMenuThemeEditor();
+	}
 }
 
 /*

--- a/src/content-scripts/themes.js
+++ b/src/content-scripts/themes.js
@@ -49,7 +49,7 @@ function validFont(font){
 	return FONTS_LIST.includes(font);
 }
 
-browser.storage.local.get({"theme":{}}, function(result)
+chrome.storage.local.get({"theme":{}}, function(result)
 {
 	let themeSettings = result.theme;
 	console.log(themeSettings);
@@ -97,7 +97,7 @@ function changeTheme(theme, onload=false)
 		theme = "themes/none.css"
 	}
 
-	let css = browser.runtime.getURL(theme)
+	let css = chrome.runtime.getURL(theme)
 	// because dynamic paths, otherwise it won't work
 	themeStylesheet.setAttribute('href', css);
 	themeStyle.innerHTML = "";
@@ -159,14 +159,14 @@ main .h-full.flex-col > div {
 
 function changeThemeSetting(settingName, settingValue)
 {
-	browser.storage.local.get({"theme":{}}, (result) =>
+	chrome.storage.local.get({"theme":{}}, (result) =>
 	{
 		let themeSettings = result.theme;
 		if(typeof themeSettings === "string") themeSettings = {"theme": themeSettings};
 		
 		themeSettings[settingName] = settingValue;
 		
-		browser.storage.local.set({theme: themeSettings});
+		chrome.storage.local.set({theme: themeSettings});
 	});
 }
 
@@ -325,7 +325,7 @@ function createCustomStyleButton()
 	wrapper.addEventListener("click", ()=>
 	{
 		customStyleEditor.style.visibility = "visible";
-		browser.storage.local.get({"theme":{}}, (result) =>
+		chrome.storage.local.get({"theme":{}}, (result) =>
 		{
 			let themeSettings = result.theme;
 			let customCSS = themeSettings?.customCSS;
@@ -525,7 +525,7 @@ function readdThemeSelect()
 function initializeThemes()
 {
 	console.log(`Loading themes...`);
-	themeStylesheet = injectStylesheet(browser.runtime.getURL('themes/none.css'));
+	themeStylesheet = injectStylesheet(chrome.runtime.getURL('themes/none.css'));
 	fontStyle = injectStyle();
 	themeStyle = injectStyle();
 	customStyle = injectStyle();

--- a/src/themes/hacker.css
+++ b/src/themes/hacker.css
@@ -83,32 +83,32 @@ main > div.absolute > form > div > div.flex.flex-col:before
   font-size: 16px;
 }
 
-.btn-neutral
+main .btn-neutral
 {
   background-color: #05321e;
   color: inherit;
   border: none;
 }
 
-.btn-neutral:hover
+main .btn-neutral:hover
 {
   background-color: #15422e;
 }
 
-.dark .btn-neutral
+main .dark .btn-neutral
 {
   background-color: #05321e;
   color: inherit;
   border: none;
 }
 
-.btn-primary
+main .btn-primary
 {
   background-color: #05321e;
   color: inherit;
 }
 
-.btn-primary:hover
+main .btn-primary:hover
 {
   background-color: #15422e;
   color: inherit;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/79041835/217501273-fbf97cdc-2952-4390-9050-b600b5b730d4.png)
- Moved theme buttons to a popup menu to save space
    - I'm thinking this will be the basis of the basic theme editor. Keep it simple. 
- Added an advanced style editor which is to just inject CSS. What could go wrong? (At least it's not arbitrary JS)
    - TBH I don't quite like it because it's kind of crude, but it's the kind of last resort that some people might want.

Before the release, I kinda wanna disable the editor for now (one can just comment out the append button `menuThemeEditorElement.appendChild(customStyleButton);` on line `472`), and hold off on releasing the advanced theme editor until the *basic* theme editor is up and running, with more options like "background image" and "soundscape".

Known issues:
![image](https://user-images.githubusercontent.com/79041835/217501129-1e587b62-e988-4b29-bbf2-084ababe14d5.png)
Advanced theme editor breaks at small widths.