### PR TITLE
disable scraping for non_unified_ids entirely

### DIFF
--- a/src/content-scripts/scraper.js
+++ b/src/content-scripts/scraper.js
@@ -228,7 +228,7 @@ function startScraper() {
                         current_leaf = new_current_leaf;
                     }
                 }
-                //console.log(mirror_branch_state.toJSON());
+                
                 if (mirror_branch_state.toJSON() !== null) {
                     if (!previous_convo){
                         let conversation_id_el = document.querySelector('#conversationID');
@@ -241,73 +241,77 @@ function startScraper() {
                             }
                         }
                     }
-                    if (t !== null) {
-                        if (first_time) {
-                            let thread = {
-                                date: getDate(),
-                                time: getTime(),
-                                convo: page,
-                                favorite: false,
-                                id: id,
-                                branch_state: mirror_branch_state.toJSON(),
-                                unified_id: unified_id,
-                            }
-                            first_time = false
-                            if (!previous_convo) {
-                                let title = getTitle()
-                                if (title !== "New chat"){
-                                    thread.title = title
-                                }
-                            }
-                            t.push(thread)
-                        }
-                        else {
-                            let thread = {
-                                date: getDate(),
-                                time: getTime(),
-                                convo: page,
-                                favorite: false,
-                                id: id,
-                                branch_state: mirror_branch_state.toJSON(),
-                                unified_id: unified_id,
-                            }
-                            if (!previous_convo) {
-                                let title = getTitle()
-                                if (title !== "New chat"){
-                                    thread.title = title
-                                }
-                            }
-							let threadIndex = getObjectIndexByID(id, t);
-							if(threadIndex !== null)
-							{
-								t[threadIndex] = thread;
+					
+					if(unified_id)
+					{
+						if (t !== null) {
+							if (first_time) {
+								let thread = {
+									date: getDate(),
+									time: getTime(),
+									convo: page,
+									favorite: false,
+									id: id,
+									branch_state: mirror_branch_state.toJSON(),
+									unified_id: unified_id,
+								}
+								first_time = false
+								if (!previous_convo) {
+									let title = getTitle()
+									if (title !== "New chat"){
+										thread.title = title
+									}
+								}
+								t.push(thread)
 							}
-							else 
-							{
-								t.push(thread);
+							else {
+								let thread = {
+									date: getDate(),
+									time: getTime(),
+									convo: page,
+									favorite: false,
+									id: id,
+									branch_state: mirror_branch_state.toJSON(),
+									unified_id: unified_id,
+								}
+								if (!previous_convo) {
+									let title = getTitle()
+									if (title !== "New chat"){
+										thread.title = title
+									}
+								}
+								let threadIndex = getObjectIndexByID(id, t);
+								if(threadIndex !== null)
+								{
+									t[threadIndex] = thread;
+								}
+								else 
+								{
+									t.push(thread);
+								}
 							}
-                        }
-                        chrome.storage.local.set({threads: t})
-                    }
-                    else { // very first conversation scraping
-                        let thread = {
-                            date: getDate(),
-                            time: getTime(),
-                            convo: page,
-                            favorite: false,
-                            id: id,
-                            branch_state: mirror_branch_state.toJSON(),
-                        }
-                        if (!previous_convo) {
-                            let title = getTitle()
-                            if (title !== "New chat"){
-                                thread.title = title
-                            }
-                        }
-                        let t = [thread]
-                        first_time = false
-                        chrome.storage.local.set({threads: t})
-                    }
+							chrome.storage.local.set({threads: t})
+						}
+						else { // very first conversation scraping
+							let thread = {
+								date: getDate(),
+								time: getTime(),
+								convo: page,
+								favorite: false,
+								id: id,
+								branch_state: mirror_branch_state.toJSON(),
+							}
+							if (!previous_convo) {
+								let title = getTitle()
+								if (title !== "New chat"){
+									thread.title = title
+								}
+							}
+							let t = [thread]
+							first_time = false
+							chrome.storage.local.set({threads: t})
+						}
+					}
                 }
             });
         }


### PR DESCRIPTION
there is no good reason to scrape *new* non `unified_id`'s, and as we have seen, it has caused these bugs in #145. This will fix *one* version of the bug for old convos, but not necessarily with new convos since the scraper is still broken in other ways. like the fact that non `unified_id`'s are even scrapped at all.

in fact, due to the other bugs, the scraper will frequently refuse to scrape at all.

This is a 'hotfix', so depending on how urgently you want to incorporate it or if you want to wait for the other bugs to be fixed first.

@benf2004 I still don't have access to new Bing, so I think it'll make more sense for me to work on fixing the old scraper while you build the new scraper for Bing.

Currently working on an entire refactor of the scraper and trying to decompose the monster function; hopefully with some more globals we'll fix the memory leak (I bet that's the first time globals have been used to *solve* a problem).

PS: I was working on utilities.js and accidentally worked on the wrong file. I was questioning my sanity for a good long hour before realizing my mistake. But in future, I think I'm going to start making every file name unique.