### PR TITLE
Menu buttons bodge

### DIFF
--- a/src/content-scripts/export-buttons.js
+++ b/src/content-scripts/export-buttons.js
@@ -283,7 +283,6 @@ const ExportButtons = (function()
 	// listen for URLChange to add buttons
 	window.addEventListener("message", (event) =>
 	{
-		console.log("Export Buttons Message");
 		// readd buttons on URL change 
 		if(event.data?.type === "urlChange")
 		{

--- a/src/content-scripts/export-buttons.js
+++ b/src/content-scripts/export-buttons.js
@@ -290,6 +290,12 @@ const ExportButtons = (function()
 			// of course, we must set timeout, because otherwise the main app will delete it 
 			setTimeout(ExportButtons.addButtons, ADD_BUTTONS_DELAY);
 		}
+		else if(event.data?.type === "readdExportButtons")
+		{
+			// no delay, since presumably this is after everything else has loaded
+			// and since it's idempotent, it doesn't matter how many times we call it. no handling necessary
+			ExportButtons.addButtons();
+		}
 	});
 	return {
 		/**

--- a/src/content-scripts/export-inject.js
+++ b/src/content-scripts/export-inject.js
@@ -4,7 +4,6 @@ function addExportButtons()
 	chrome.storage.local.get({settings: defaults}, function (result) {
         let settings = result.settings;
         buttonsFlag = settings.buttons ?? true;
-		
         if (buttonsFlag === true) {
 			
 			// we inject script to try to defeat CORS not allowing us to save images
@@ -19,5 +18,6 @@ function addExportButtons()
         }
 		readdThemeSelect(); // just going to yoink this in here, from themes.js, as this is more convenient.
     });
+
 }
 addExportButtons();

--- a/src/content-scripts/export.js
+++ b/src/content-scripts/export.js
@@ -9,7 +9,22 @@ function check_url() {
 				type: "urlChange"
 			}, "*");
 		setTimeout(readdThemeSelect, 500);
-        console.log("URL CHANGE")
+        console.log("URL CHANGE");
     }
+	
+	// throw in other checks for convenience's sake. I know it's probably bad practice 
+	// but I'm too lazy to write a main() right now
+	
+	// basically, constantly vigils and readds the menu buttons if they disappear for whatever reason
+	if (!document.getElementById('download-markdown-button')) {
+		window.postMessage(
+			{
+				type: "readdExportButtons"
+			}, "*");
+	}
+	if (!document.getElementById('menu-theme-editor-button')) {
+		readdThemeSelect();
+	}
+	
 }
 setInterval(check_url, 500);

--- a/src/pages/settings.html
+++ b/src/pages/settings.html
@@ -75,7 +75,7 @@
                     </div>
                 </td>
             </tr>
-            <tr class="d-none export">
+            <tr class="export">
                 <td>Show export button dropdown</td>
                 <td>
                     <div class="form-check form-switch">


### PR DESCRIPTION
Fixes #176 by showing menu settings, allowing users to *finally* change that setting.
Fixes #170 using the watchdog bodge, ie, constantly rechecking and checking if the buttons are gone for whatever reason (though it still doesn't work on mobile mode)

More longterm testing is needed, but it seems to work just fine.