### PR TITLE
Fix a bug on hover in prompts.css

### DIFF
--- a/src/pages/css/prompts.css
+++ b/src/pages/css/prompts.css
@@ -81,7 +81,7 @@ body.dark{
     border-top: #E5E5E5 1px solid;
 }
 .row:hover{
-    border: #0BA37F 2px solid;
+    box-shadow: 0 0 0 2px #0BA37F;
 }
 
 .square-icon {


### PR DESCRIPTION
Using box-shadow is used instead of border to fix the displacement bug on .row:hover