### PR TITLE
Fix .row:hover in prompts.css

### DIFF
--- a/src/pages/css/prompts.css
+++ b/src/pages/css/prompts.css
@@ -86,7 +86,7 @@ a {
     border-top: #E5E5E5 1px solid;
 }
 .row:hover{
-    border: #0BA37F 2px solid;
+    box-shadow: 0 0 0 2px #0BA37F inset;
 }
 
 .square-icon {


### PR DESCRIPTION
A robust fix for showing border on hover for .row 