### PR TITLE
Fix full-width parenthesis for Chinese language options

### DIFF
--- a/src/pages/settings.html
+++ b/src/pages/settings.html
@@ -110,10 +110,10 @@
                 <select class="select form-select w-50" id="selectLang">
                   <option value="en">English</option>
                   <option value="zh_CN">
-                    Chinese (Simplified) - 中文（简体)
+                    Chinese (Simplified) - 中文（简体）
                   </option>
                   <option value="zh_TW">
-                    Chinese (Traditional) - 中文（繁體)
+                    Chinese (Traditional) - 中文（繁體）
                   </option>
                   <option value="de">German - Deutsch</option>
                   <option value="fr">French - français</option>


### PR DESCRIPTION
Adjusted `)` to `）` for consistency and to align with the standard use of full-width punctuation in Chinese.